### PR TITLE
refactor: use type predicates

### DIFF
--- a/src/common/serialize.ts
+++ b/src/common/serialize.ts
@@ -19,7 +19,7 @@ import { tryJSONParse, tryJSONStringify } from './index';
 import { isObject } from './validate';
 
 export function serializeType(value: unknown) {
-  if (typeof value === 'object' && !Array.isArray(value) && !(value === null)) {
+  if (isObject(value)) {
     return {
       type: 'object',
       value: serializeObject(value),

--- a/src/common/validate.ts
+++ b/src/common/validate.ts
@@ -91,7 +91,7 @@ export function isString(value: unknown) {
  * @param value
  * @return {boolean}
  */
-export function isNumber(value: unknown) {
+export function isNumber(value: unknown): value is number {
   return typeof value === 'number';
 }
 
@@ -137,7 +137,7 @@ export function isArray(value: unknown) {
  * @param value
  * @returns {boolean}
  */
-export function isUndefined(value: unknown) {
+export function isUndefined(value: unknown): value is undefined {
   return typeof value === 'undefined';
 }
 

--- a/src/internal/registry/nativeModule.ts
+++ b/src/internal/registry/nativeModule.ts
@@ -20,6 +20,7 @@ import { APP_NATIVE_MODULE } from '../constants';
 import { NativeError } from '../NativeError';
 import { GoogleAdsNativeEventEmitter } from '../GoogleAdsNativeEventEmitter';
 import { SharedEventEmitter } from '../SharedEventEmitter';
+import { isFunction } from '../../common';
 import { ModuleInterface } from '../../types/Module.interface';
 
 const NATIVE_MODULE_REGISTRY: Record<string, unknown> = {};
@@ -78,7 +79,7 @@ function nativeModuleWrapped(
 
   for (let i = 0, len = properties.length; i < len; i++) {
     const property = properties[i];
-    if (typeof NativeModule[property] === 'function') {
+    if (isFunction(NativeModule[property])) {
       native[property] = nativeModuleMethodWrapped(namespace, NativeModule[property], argToPrepend);
     } else {
       native[property] = NativeModule[property];

--- a/src/validateAdRequestOptions.ts
+++ b/src/validateAdRequestOptions.ts
@@ -22,6 +22,7 @@ import {
   isNumber,
   isObject,
   isString,
+  isUndefined,
   isValidUrl,
 } from './common';
 import { RequestOptions } from './types/RequestOptions';
@@ -29,7 +30,7 @@ import { RequestOptions } from './types/RequestOptions';
 export function validateAdRequestOptions(options?: RequestOptions) {
   const out: RequestOptions = {};
 
-  if (options === undefined) {
+  if (isUndefined(options)) {
     return out;
   }
 
@@ -126,7 +127,7 @@ export function validateAdRequestOptions(options?: RequestOptions) {
       throw new Error("'options.locationAccuracy' expected a number value.");
     }
 
-    if (typeof options.locationAccuracy === 'number' && options.locationAccuracy < 0) {
+    if (isNumber(options.locationAccuracy) && options.locationAccuracy < 0) {
       throw new Error("'options.locationAccuracy' expected a number greater than 0.");
     }
 

--- a/src/validateAdShowOptions.ts
+++ b/src/validateAdShowOptions.ts
@@ -15,13 +15,13 @@
  *
  */
 
-import { hasOwnProperty, isBoolean, isObject } from './common';
+import { hasOwnProperty, isBoolean, isObject, isUndefined } from './common';
 import { AdShowOptions } from './types/AdShowOptions';
 
 export function validateAdShowOptions(options?: AdShowOptions) {
   const out: AdShowOptions = {};
 
-  if (options === undefined) {
+  if (isUndefined(options)) {
     return out;
   }
 


### PR DESCRIPTION
Currently some type validation helpers from common weren't used as those resulted in TS errors.
By defining a "Type predicate", TS understands the validation functions.
https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates