### PR TITLE
docs(docs): fixed syntax error

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -93,7 +93,7 @@ admob()
     tagForUnderAgeOfConsent: true,
 
     // An array of test device IDs to whitelist.
-    testDeviceIdentifiers: ["EMULATOR"];
+    testDeviceIdentifiers: ["EMULATOR"]
   })
   .then(() => {
     // Request config successfully set!


### PR DESCRIPTION
Removed erroneous semi-colon in code snippet

### Description

Fixed syntax error in documentation 

### Related issues

N/A

### Release Summary

N/A

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [ X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No

### Test Plan

N/A


