### PR TITLE
build(patches): remove reference to previous scoped package dir

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -69,7 +69,7 @@ jobs:
           mkdir patches || true
           echo "Installing $CLEAN_PACKAGE_NAME into fresh template app, then clobbering with PR version"
           yarn add $PACKAGE_NAME
-          pushd node_modules/@invertase
+          pushd node_modules/
           tar -zxf $HOME/scratch/*$CLEAN_PACKAGE_NAME*-v*
           mv react-native-google-mobile-ads/package.json package/
           \rm -fr react-native-google-mobile-ads


### PR DESCRIPTION

### Description

with the previous scoped package name we needed to pushd to `@invertase`, that is unnecessary and causes an error now

### Related issues

Nothing logged, but I watch CI and saw failures...

### Release Summary

It is a conventional commit so it *should* be okay to rebase merge. Always verify that assertion though :-)

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Not sure if this is testable pre-merge, it *may* run correctly on the branch for the PR. If not it may need merging, then we will see if the patch-packages zip is created successfully
---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
