### PR TITLE
fix: adRequestOptions ignored in fullscreen formats

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.java
@@ -17,6 +17,7 @@ package io.invertase.googlemobileads;
  *
  */
 
+import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsCommon.buildAdRequest;
 import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsCommon.getCodeAndMessageFromAdError;
 import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsCommon.sendAdEvent;
 import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_APP_OPEN;
@@ -34,7 +35,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.appopen.AppOpenAd;
@@ -67,9 +67,6 @@ public class ReactNativeGoogleMobileAdsAppOpenModule extends ReactNativeModule {
     }
     currentActivity.runOnUiThread(
         () -> {
-          AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
-          AdRequest adRequest = adRequestBuilder.build();
-
           AppOpenAd.AppOpenAdLoadCallback appOpenAdLoadCallback =
               new AppOpenAd.AppOpenAdLoadCallback() {
 
@@ -115,7 +112,7 @@ public class ReactNativeGoogleMobileAdsAppOpenModule extends ReactNativeModule {
           AppOpenAd.load(
               currentActivity,
               adUnitId,
-              adRequest,
+              buildAdRequest(adRequestOptions),
               AppOpenAd.APP_OPEN_AD_ORIENTATION_PORTRAIT,
               appOpenAdLoadCallback);
         });

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.java
@@ -17,6 +17,7 @@ package io.invertase.googlemobileads;
  *
  */
 
+import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsCommon.buildAdRequest;
 import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsCommon.getCodeAndMessageFromAdError;
 import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsCommon.sendAdEvent;
 import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_CLICKED;
@@ -35,7 +36,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.interstitial.InterstitialAd;
@@ -69,9 +69,6 @@ public class ReactNativeGoogleMobileAdsInterstitialModule extends ReactNativeMod
     }
     currentActivity.runOnUiThread(
         () -> {
-          AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
-          AdRequest adRequest = adRequestBuilder.build();
-
           InterstitialAdLoadCallback interstitialAdLoadCallback =
               new InterstitialAdLoadCallback() {
 
@@ -114,7 +111,11 @@ public class ReactNativeGoogleMobileAdsInterstitialModule extends ReactNativeMod
                 }
               };
 
-          InterstitialAd.load(currentActivity, adUnitId, adRequest, interstitialAdLoadCallback);
+          InterstitialAd.load(
+              currentActivity,
+              adUnitId,
+              buildAdRequest(adRequestOptions),
+              interstitialAdLoadCallback);
         });
   }
 

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModule.java
@@ -1,5 +1,6 @@
 package io.invertase.googlemobileads;
 
+import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsCommon.buildAdRequest;
 import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsCommon.getCodeAndMessageFromAdError;
 import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsCommon.sendAdEvent;
 import static io.invertase.googlemobileads.ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_CLOSED;
@@ -18,7 +19,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.OnUserEarnedRewardListener;
@@ -64,8 +64,6 @@ public class ReactNativeGoogleMobileAdsRewardedModule extends ReactNativeModule 
     }
     activity.runOnUiThread(
         () -> {
-          AdRequest adRequest = new AdRequest.Builder().build();
-
           RewardedAdLoadCallback rewardedAdLoadCallback =
               new RewardedAdLoadCallback() {
                 @Override
@@ -129,7 +127,8 @@ public class ReactNativeGoogleMobileAdsRewardedModule extends ReactNativeModule 
                 }
               };
 
-          RewardedAd.load(activity, adUnitId, adRequest, rewardedAdLoadCallback);
+          RewardedAd.load(
+              activity, adUnitId, buildAdRequest(adRequestOptions), rewardedAdLoadCallback);
         });
   }
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.m
@@ -43,9 +43,8 @@ RCT_EXPORT_METHOD(appOpenLoad
                   : (NSString *)adUnitId
                   : (NSDictionary *)adRequestOptions) {
   self.appOpenAd = nil;
-  GADRequest *request = [GADRequest request];
   [GADAppOpenAd loadWithAdUnitID:adUnitId
-                         request:request
+                         request:[RNGoogleMobileAdsCommon buildAdRequest:adRequestOptions]
                      orientation:UIInterfaceOrientationPortrait
                completionHandler:^(GADAppOpenAd *_Nullable appOpenAd, NSError *_Nullable error) {
                  if (error) {

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.m
@@ -68,9 +68,8 @@ RCT_EXPORT_METHOD(interstitialLoad
                   : (nonnull NSNumber *)requestId
                   : (NSString *)adUnitId
                   : (NSDictionary *)adRequestOptions) {
-  GADRequest *request = [GADRequest request];
   [GADInterstitialAd loadWithAdUnitID:adUnitId
-                              request:request
+                              request:[RNGoogleMobileAdsCommon buildAdRequest:adRequestOptions]
                     completionHandler:^(GADInterstitialAd *ad, NSError *error) {
                       if (error) {
                         NSDictionary *codeAndMessage =

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.m
@@ -68,9 +68,8 @@ RCT_EXPORT_METHOD(rewardedLoad
                   : (nonnull NSNumber *)requestId
                   : (NSString *)adUnitId
                   : (NSDictionary *)adRequestOptions) {
-  GADRequest *request = [GADRequest request];
   [GADRewardedAd loadWithAdUnitID:adUnitId
-                          request:request
+                          request:[RNGoogleMobileAdsCommon buildAdRequest:adRequestOptions]
                 completionHandler:^(GADRewardedAd *ad, NSError *error) {
                   if (error) {
                     NSDictionary *codeAndMessage =


### PR DESCRIPTION
### Description

I found that in both the iOS SDK & Android SDK upgrades, the adRequestOptions for fullscreen ads were ignored.
https://github.com/invertase/react-native-google-mobile-ads/pull/30
https://github.com/invertase/react-native-google-mobile-ads/pull/32