### PR TITLE
docs(ios): Replace pod install with npx pod-install

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -62,7 +62,7 @@ For the changes to take effect, rebuild your project:
 
 ```bash
 # For iOS
-cd ios/ && pod install
+npx pod-install
 npx react-native run-ios
 
 # For Android


### PR DESCRIPTION
This npx command is convenient method for installing packages and doesnt need to going in and out ./ios folder

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


🔥
