### PR TITLE
feat: add full screen ad hooks

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4,8 +4,9 @@
   "sidebar": [
     ["Installation", "/"],
     ["Displaying Ads", "/displaying-ads"],
+    ["Displaying Ads via Hook", "/displaying-ads-hook"],
     ["European User Consent", "/european-user-consent"],
     ["Common Reasons For Ads Not Showing", "/common-reasons-for-ads-not-showing"],
     ["Migrating to v5", "/migrating-to-v5"]
   ]
-} 
+}

--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -2,7 +2,7 @@
 
 The AdMob package provides hooks to help you to display ads in a functional component with tiny code. The supported ad formats are full-screen ads: App open, Interstitial & Rewarded.
 
-## Creating ad
+## Load an ad
 
 You can create a new ad by adding a corresponding ad type's hook to your component.
 

--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -22,7 +22,7 @@ export default function App() {
 }
 ```
 
-> `adUnitid` parameter is also can be used to manage creation and destruction of ad instance.
+> The `adUnitid` parameter can also be used to manage creation and destruction of an ad instance.
 > If `adUnitid` is set or changed, new ad instance will be created and previous ad instance will be destroyed if exists.
 > If `adUnitid` is set to `null`, no ad instance will be created and previous ad instance will be destroyed if exists.
 

--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -1,6 +1,6 @@
 # Hooks
 
-The AdMob package provides hooks to help you to display ads in functional component with tiny code. The supported ad formats are full-screen-type-ads: AppOpen, Interstitial, Rewarded.
+The AdMob package provides hooks to help you to display ads in a functional component with tiny code. The supported ad formats are full-screen ads: App open, Interstitial & Rewarded.
 
 ## Creating ad
 

--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -30,7 +30,7 @@ The second argument is additional optional request options object to be sent whi
 Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](/reference/admob/requestoptions)
 documentation to view the full range of options available.
 
-## Displaying ad
+## Show the ad
 
 The hook returns several states and functions to control ad.
 

--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -1,0 +1,99 @@
+# Hooks
+
+The AdMob package provides hooks to help you to display ads in functional component with tiny code. The supported ad formats are full-screen-type-ads: AppOpen, Interstitial, Rewarded.
+
+## Creating ad
+
+You can create a new ad by adding a corresponding ad type's hook to your component.
+
+The first argument of the hook is the "Ad Unit ID".
+For testing, we can use a Test ID, however for production the ID from the
+Google AdMob dashboard under "Ad units" should be used:
+
+```tsx {4-8}
+import { useInterstitialAd, TestIds } from 'react-native-google-mobile-ads';
+
+export default function App() {
+  const interstitialAd = useInterstitialAd(TestIds.Interstitial, {
+    requestNonPersonalizedAdsOnly: true,
+  });
+
+  return <View>{/* ... */}</View>;
+}
+```
+
+> `adUnitid` parameter is also can be used to manage creation and destruction of ad instance.
+> If `adUnitid` is set or changed, new ad instance will be created and previous ad instance will be destroyed if exists.
+> If `adUnitid` is set to `null`, no ad instance will be created and previous ad instance will be destroyed if exists.
+
+The second argument is additional optional request options object to be sent whilst loading an advert, such as keywords & location.
+Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](/reference/admob/requestoptions)
+documentation to view the full range of options available.
+
+## Displaying ad
+
+The hook returns several states and functions to control ad.
+
+```tsx
+import { useInterstitialAd, TestIds } from 'react-native-google-mobile-ads';
+
+export default function App({ navigation }) {
+  const { isLoaded, isClosed, load, show } = useInterstitialAd(TestIds.Interstitial, {
+    requestNonPersonalizedAdsOnly: true,
+  });
+
+  useEffect(() => {
+    // Start loading the interstitial straight away
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (isClosed) {
+      // Action after the ad is closed
+      navigation.navigate('NextScreen');
+    }
+  }, [isClosed, navigation]);
+
+  return (
+    <View>
+      <Button
+        title="Navigate to next screen"
+        onPress={() => {
+          if (isLoaded) {
+            show();
+          } else {
+            // No advert ready to show yet
+            navigation.navigate('NextScreen');
+          }
+        }}
+      />
+    </View>
+  );
+}
+```
+
+The code above immediately starts to load a new advert from the network (via `load()`).
+When user presses button, it checks if the ad is loaded via `isLoaded` value,
+then the `show` function is called and the advert is shown over-the-top of your application.
+Otherwise, if the ad is not loaded, the `navigation.navigate` method is called to navigate to the next screen without showing the ad.
+After the ad is closed, the `isClosed` value is set to `true` and the `navigation.navigate` method is called to navigate to the next screen.
+
+If needed, you can reuse the existing hook to load more adverts and show them when required. The states are initialized when the `load` function is called.
+
+Return values of the hook are:
+
+| Name           | Type                               | Description                                                                                                        |
+| :------------- | :--------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
+| isLoaded       | boolean                            | Whether the ad is loaded and ready to to be shown to the user.                                                     |
+| isOpened       | boolean                            | Whether the ad is opened. The value is remained `true` even after the ad is closed unless **new ad is requested**. |
+| isClosed       | boolean                            | Whether your ad is dismissed.                                                                                      |
+| isShowing      | boolean                            | Whether your ad is showing. The value is equal with `isOpened && !isClosed`.                                       |
+| error          | Error \| undefined                 | `Error` object throwed during ad load.                                                                             |
+| reward         | [RewardedAdReward](#) \| undefined | Loaded reward item of the Rewarded Ad. Available only in RewardedAd.                                               |
+| isEarnedReward | boolean                            | Whether the user earned the reward by Rewarded Ad.                                                                 |
+| load           | Function                           | Start loading the advert with the provided RequestOptions.                                                         |
+| show           | Function                           | Show the loaded advert to the user.                                                                                |
+
+> Note that `isOpened` value remains `true` even after the ad is closed.
+> The value changes to `false` when ad is initialized via calling `load()`.
+> To determine whether the ad is currently showing, use `isShowing` value.

--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -26,7 +26,7 @@ export default function App() {
 > If `adUnitid` is set or changed, new ad instance will be created and previous ad instance will be destroyed if exists.
 > If `adUnitid` is set to `null`, no ad instance will be created and previous ad instance will be destroyed if exists.
 
-The second argument is additional optional request options object to be sent whilst loading an advert, such as keywords & location.
+The second argument is an additional optional request options object to be sent whilst loading an advert, such as keywords & location.
 Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](/reference/admob/requestoptions)
 documentation to view the full range of options available.
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {
   Button,
   SafeAreaView,
@@ -19,6 +19,7 @@ import {
   BannerAd,
   BannerAdSize,
   RewardedAd,
+  useInterstitialAd,
 } from 'react-native-google-mobile-ads';
 
 const appOpenAdUnitId = TestIds.APP_OPEN;
@@ -244,12 +245,55 @@ class AdConsentTest implements Test {
   }
 }
 
+const HookComponent = React.forwardRef<View>((_, ref) => {
+  const {load, show} = useInterstitialAd(TestIds.INTERSTITIAL);
+  useEffect(() => {
+    load();
+  }, [load]);
+  return (
+    <View style={styles.testSpacing} ref={ref}>
+      <Button
+        title="Show Interstitial"
+        onPress={() => {
+          show();
+        }}
+      />
+    </View>
+  );
+});
+
+class HookTest implements Test {
+  getPath(): string {
+    return 'Hook';
+  }
+
+  getTestType(): TestType {
+    return TestType.Interactive;
+  }
+
+  render(onMount: (component: any) => void): React.ReactNode {
+    return <HookComponent ref={onMount} />;
+  }
+
+  execute(component: any, complete: (result: TestResult) => void): void {
+    let results = new TestResult();
+    try {
+      // You can do anything here, it will execute on-device + in-app. Results are aggregated + visible in-app.
+    } catch (error) {
+      results.errors.push('Received unexpected error...');
+    } finally {
+      complete(results);
+    }
+  }
+}
+
 // All tests must be registered - a future feature will allow auto-bundling of tests via configured path or regex
 TestRegistry.registerTest(new BannerTest());
 TestRegistry.registerTest(new AppOpenTest());
 TestRegistry.registerTest(new InterstitialTest());
 TestRegistry.registerTest(new RewaredTest());
 TestRegistry.registerTest(new AdConsentTest());
+TestRegistry.registerTest(new HookTest());
 
 const App = () => {
   return (

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -386,7 +386,7 @@ PODS:
     - React-jsi (= 0.67.3)
     - React-logger (= 0.67.3)
     - React-perflogger (= 0.67.3)
-  - RNGoogleMobileAds (4.2.0):
+  - RNGoogleMobileAds (5.0.0):
     - Google-Mobile-Ads-SDK (= 8.13.0)
     - GoogleUserMessagingPlatform (= 2.0.0)
     - React-Core
@@ -591,7 +591,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: d0361f15ea978958fab7ffb6960f475b5063d83f
   React-runtimeexecutor: af1946623656f9c5fd64ca6f36f3863516193446
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
-  RNGoogleMobileAds: ae52d9f8048e7a5f5139b9440fec5a839175b9a5
+  RNGoogleMobileAds: 3b35145daceeb09105dcafa4778d65678486a53a
   Yoga: 90dcd029e45d8a7c1ff059e8b3c6612ff409061a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2869,6 +2869,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+dequal@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -7630,6 +7635,14 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+use-deep-compare-effect@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz#ef0ce3b3271edb801da1ec23bf0754ef4189d0c6"
+  integrity sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    dequal "^2.0.2"
 
 use-subscription@^1.0.0:
   version "1.5.1"

--- a/package.json
+++ b/package.json
@@ -141,5 +141,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "use-deep-compare-effect": "^1.8.1"
   }
 }

--- a/src/hooks/useAppOpenAd.ts
+++ b/src/hooks/useAppOpenAd.ts
@@ -17,8 +17,8 @@
 
 import { useState } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { AppOpenAd } from '../ads/AppOpenAd';
 
+import { AppOpenAd } from '../ads/AppOpenAd';
 import { AdHookReturns } from '../types/AdStates';
 import { RequestOptions } from '../types/RequestOptions';
 
@@ -27,7 +27,7 @@ import { useFullScreenAd } from './useFullScreenAd';
 /**
  * React Hook for App Open Ad.
  *
- * @param adUnitId The Ad Unit ID for the App Open Ad. You can find this on your Google Mobile Ads dashboard.
+ * @param adUnitId The Ad Unit ID for the App Open Ad. You can find this on your Google Mobile Ads dashboard. You can destroy ad instance by setting this value to null.
  * @param requestOptions Optional RequestOptions used to load the ad.
  */
 export function useAppOpenAd(

--- a/src/hooks/useAppOpenAd.ts
+++ b/src/hooks/useAppOpenAd.ts
@@ -38,7 +38,6 @@ export function useAppOpenAd(
 
   useDeepCompareEffect(() => {
     setAppOpenAd(() => {
-      //prevAd?.destroy();
       return adUnitId ? AppOpenAd.createForAdRequest(adUnitId, requestOptions) : null;
     });
   }, [adUnitId, requestOptions]);

--- a/src/hooks/useAppOpenAd.ts
+++ b/src/hooks/useAppOpenAd.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { useState } from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
+import { AppOpenAd } from '../ads/AppOpenAd';
+
+import { AdHookReturns } from '../types/AdStates';
+import { RequestOptions } from '../types/RequestOptions';
+
+import { useFullScreenAd } from './useFullScreenAd';
+
+/**
+ * React Hook for App Open Ad.
+ *
+ * @param adUnitId The Ad Unit ID for the App Open Ad. You can find this on your Google Mobile Ads dashboard.
+ * @param requestOptions Optional RequestOptions used to load the ad.
+ */
+export function useAppOpenAd(
+  adUnitId: string | null,
+  requestOptions?: RequestOptions,
+): Omit<AdHookReturns, 'adReward'> {
+  const [appOpenAd, setAppOpenAd] = useState<AppOpenAd | null>(null);
+
+  useDeepCompareEffect(() => {
+    setAppOpenAd(() => {
+      //prevAd?.destroy();
+      return adUnitId ? AppOpenAd.createForAdRequest(adUnitId, requestOptions) : null;
+    });
+  }, [adUnitId, requestOptions]);
+
+  return useFullScreenAd(appOpenAd);
+}

--- a/src/hooks/useAppOpenAd.ts
+++ b/src/hooks/useAppOpenAd.ts
@@ -32,7 +32,7 @@ import { useFullScreenAd } from './useFullScreenAd';
  */
 export function useAppOpenAd(
   adUnitId: string | null,
-  requestOptions?: RequestOptions,
+  requestOptions: RequestOptions = {},
 ): Omit<AdHookReturns, 'adReward'> {
   const [appOpenAd, setAppOpenAd] = useState<AppOpenAd | null>(null);
 

--- a/src/hooks/useFullScreenAd.ts
+++ b/src/hooks/useFullScreenAd.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { Reducer, useCallback, useEffect, useReducer } from 'react';
+import { AdEventType } from '../AdEventType';
+
+import { AppOpenAd } from '../ads/AppOpenAd';
+import { InterstitialAd } from '../ads/InterstitialAd';
+import { RewardedAd } from '../ads/RewardedAd';
+import { RewardedAdEventType } from '../RewardedAdEventType';
+import { AdStates, AdHookReturns } from '../types/AdStates';
+import { AdShowOptions } from '../types/AdShowOptions';
+
+const initialState: AdStates = {
+  isLoaded: false,
+  isOpened: false,
+  isClicked: false,
+  isClosed: false,
+  error: undefined,
+  reward: undefined,
+  isEarnedReward: false,
+};
+
+export function useFullScreenAd<T extends InterstitialAd | RewardedAd | AppOpenAd | null>(
+  ad: T,
+): AdHookReturns {
+  const [state, setState] = useReducer<Reducer<AdStates, Partial<AdStates>>>(
+    (prevState, newState) => ({ ...prevState, ...newState }),
+    initialState,
+  );
+  const isShowing = state.isOpened && !state.isClosed;
+
+  const load = useCallback(() => {
+    if (ad) {
+      setState(initialState);
+      ad.load();
+    }
+  }, [ad]);
+
+  const show = useCallback(
+    (showOptions?: AdShowOptions) => {
+      if (ad) {
+        ad.show(showOptions);
+      }
+    },
+    [ad],
+  );
+
+  useEffect(() => {
+    setState(initialState);
+    if (!ad) {
+      return;
+    }
+    const unsubscribe = ad.onAdEvent((type, error, data) => {
+      switch (type) {
+        case AdEventType.LOADED:
+          setState({ isLoaded: true });
+          break;
+        case AdEventType.OPENED:
+          setState({ isOpened: true });
+          break;
+        case AdEventType.CLOSED:
+          setState({ isClosed: true });
+          break;
+        case AdEventType.CLICKED:
+          setState({ isClicked: true });
+          break;
+        case AdEventType.ERROR:
+          setState({ error: error });
+          break;
+        case RewardedAdEventType.LOADED:
+          setState({ isLoaded: true, reward: data });
+          break;
+        case RewardedAdEventType.EARNED_REWARD:
+          setState({ isEarnedReward: true, reward: data });
+          break;
+      }
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [ad]);
+
+  return {
+    ...state,
+    isShowing,
+    load,
+    show,
+  };
+}

--- a/src/hooks/useFullScreenAd.ts
+++ b/src/hooks/useFullScreenAd.ts
@@ -16,8 +16,8 @@
  */
 
 import { Reducer, useCallback, useEffect, useReducer } from 'react';
-import { AdEventType } from '../AdEventType';
 
+import { AdEventType } from '../AdEventType';
 import { AppOpenAd } from '../ads/AppOpenAd';
 import { InterstitialAd } from '../ads/InterstitialAd';
 import { RewardedAd } from '../ads/RewardedAd';

--- a/src/hooks/useInterstitialAd.ts
+++ b/src/hooks/useInterstitialAd.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { useState } from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
+
+import { InterstitialAd } from '../ads/InterstitialAd';
+import { AdHookReturns } from '../types/AdStates';
+import { RequestOptions } from '../types/RequestOptions';
+
+import { useFullScreenAd } from './useFullScreenAd';
+
+/**
+ * React Hook for Interstitial Ad.
+ *
+ * @param adUnitId The Ad Unit ID for the Interstitial Ad. You can find this on your Google Mobile Ads dashboard.
+ * @param requestOptions Optional RequestOptions used to load the ad.
+ */
+export function useInterstitialAd(
+  adUnitId: string | null,
+  requestOptions?: RequestOptions,
+): Omit<AdHookReturns, 'adReward'> {
+  const [interstitialAd, setInterstitialAd] = useState<InterstitialAd | null>(null);
+
+  useDeepCompareEffect(() => {
+    setInterstitialAd(() => {
+      //prevAd?.destroy();
+      return adUnitId ? InterstitialAd.createForAdRequest(adUnitId, requestOptions) : null;
+    });
+  }, [adUnitId, requestOptions]);
+
+  return useFullScreenAd(interstitialAd);
+}

--- a/src/hooks/useInterstitialAd.ts
+++ b/src/hooks/useInterstitialAd.ts
@@ -32,7 +32,7 @@ import { useFullScreenAd } from './useFullScreenAd';
  */
 export function useInterstitialAd(
   adUnitId: string | null,
-  requestOptions?: RequestOptions,
+  requestOptions: RequestOptions = {},
 ): Omit<AdHookReturns, 'adReward'> {
   const [interstitialAd, setInterstitialAd] = useState<InterstitialAd | null>(null);
 

--- a/src/hooks/useInterstitialAd.ts
+++ b/src/hooks/useInterstitialAd.ts
@@ -27,7 +27,7 @@ import { useFullScreenAd } from './useFullScreenAd';
 /**
  * React Hook for Interstitial Ad.
  *
- * @param adUnitId The Ad Unit ID for the Interstitial Ad. You can find this on your Google Mobile Ads dashboard.
+ * @param adUnitId The Ad Unit ID for the Interstitial Ad. You can find this on your Google Mobile Ads dashboard. You can destroy ad instance by setting this value to null.
  * @param requestOptions Optional RequestOptions used to load the ad.
  */
 export function useInterstitialAd(

--- a/src/hooks/useInterstitialAd.ts
+++ b/src/hooks/useInterstitialAd.ts
@@ -38,7 +38,6 @@ export function useInterstitialAd(
 
   useDeepCompareEffect(() => {
     setInterstitialAd(() => {
-      //prevAd?.destroy();
       return adUnitId ? InterstitialAd.createForAdRequest(adUnitId, requestOptions) : null;
     });
   }, [adUnitId, requestOptions]);

--- a/src/hooks/useRewardedAd.ts
+++ b/src/hooks/useRewardedAd.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { useState } from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
+
+import { RewardedAd } from '../ads/RewardedAd';
+import { AdHookReturns } from '../types/AdStates';
+import { RequestOptions } from '../types/RequestOptions';
+
+import { useFullScreenAd } from './useFullScreenAd';
+
+/**
+ * React Hook for Rewarded Ad.
+ *
+ * @param adUnitId The Ad Unit ID for the Rewarded Ad. You can find this on your Google Mobile Ads dashboard.
+ * @param requestOptions Optional RequestOptions used to load the ad.
+ */
+export function useRewardedAd(
+  adUnitId: string | null,
+  requestOptions?: RequestOptions,
+): Omit<AdHookReturns, 'adReward'> {
+  const [rewardedAd, setRewardedAd] = useState<RewardedAd | null>(null);
+
+  useDeepCompareEffect(() => {
+    setRewardedAd(() => {
+      //prevAd?.destroy();
+      return adUnitId ? RewardedAd.createForAdRequest(adUnitId, requestOptions) : null;
+    });
+  }, [adUnitId, requestOptions]);
+
+  return useFullScreenAd(rewardedAd);
+}

--- a/src/hooks/useRewardedAd.ts
+++ b/src/hooks/useRewardedAd.ts
@@ -32,7 +32,7 @@ import { useFullScreenAd } from './useFullScreenAd';
  */
 export function useRewardedAd(
   adUnitId: string | null,
-  requestOptions?: RequestOptions,
+  requestOptions: RequestOptions = {},
 ): Omit<AdHookReturns, 'adReward'> {
   const [rewardedAd, setRewardedAd] = useState<RewardedAd | null>(null);
 

--- a/src/hooks/useRewardedAd.ts
+++ b/src/hooks/useRewardedAd.ts
@@ -38,7 +38,6 @@ export function useRewardedAd(
 
   useDeepCompareEffect(() => {
     setRewardedAd(() => {
-      //prevAd?.destroy();
       return adUnitId ? RewardedAd.createForAdRequest(adUnitId, requestOptions) : null;
     });
   }, [adUnitId, requestOptions]);

--- a/src/hooks/useRewardedAd.ts
+++ b/src/hooks/useRewardedAd.ts
@@ -27,7 +27,7 @@ import { useFullScreenAd } from './useFullScreenAd';
 /**
  * React Hook for Rewarded Ad.
  *
- * @param adUnitId The Ad Unit ID for the Rewarded Ad. You can find this on your Google Mobile Ads dashboard.
+ * @param adUnitId The Ad Unit ID for the Rewarded Ad. You can find this on your Google Mobile Ads dashboard. You can destroy ad instance by setting this value to null.
  * @param requestOptions Optional RequestOptions used to load the ad.
  */
 export function useRewardedAd(

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,3 +33,6 @@ export { AppOpenAd } from './ads/AppOpenAd';
 export { InterstitialAd } from './ads/InterstitialAd';
 export { RewardedAd } from './ads/RewardedAd';
 export { BannerAd } from './ads/BannerAd';
+export { useAppOpenAd } from './hooks/useAppOpenAd';
+export { useInterstitialAd } from './hooks/useInterstitialAd';
+export { useRewardedAd } from './hooks/useRewardedAd';

--- a/src/types/AdStates.ts
+++ b/src/types/AdStates.ts
@@ -40,10 +40,46 @@ export interface AdHookReturns extends AdStates {
   isShowing: boolean;
   /**
    * Start loading the advert with the provided RequestOptions.
+   * #### Example
+   *
+   * ```jsx
+   * export default function App() {
+   *   const interstitial = useInterstitialAd(TestIds.INTERSTITIAL, {
+   *     requestNonPersonalizedAdsOnly: true,
+   *   });
+   *   useEffect(() => {
+   *     interstitial.load();
+   *   }, [interstitial.load]);
+   * }
+   * ```
    */
   load: () => void;
   /**
    * Show the loaded advert to the user.
+   *
+   * #### Example
+   *
+   * ```jsx
+   * export default function App() {
+   *   const interstitial = useInterstitialAd(TestIds.INTERSTITIAL, {
+   *     requestNonPersonalizedAdsOnly: true,
+   *   });
+   *   return (
+   *     <View>
+   *       <Button
+   *         title="Navigate to next screen"
+   *         onPress={() => {
+   *           if (interstitial.isLoaded) {
+   *             interstitial.show();
+   *           } else {
+   *             navigation.navigate('NextScreen');
+   *           }
+   *         }}
+   *       />
+   *     </View>
+   *   )
+   * }
+   * ```
    *
    * @param showOptions An optional `AdShowOptions` interface.
    */

--- a/src/types/AdStates.ts
+++ b/src/types/AdStates.ts
@@ -1,0 +1,51 @@
+import { AdShowOptions } from './AdShowOptions';
+import { RewardedAdReward } from './RewardedAdReward';
+
+export interface AdStates {
+  /**
+   * Whether the ad is loaded and ready to to be shown to the user.
+   */
+  isLoaded: boolean;
+  /**
+   * Whether the ad is opened.
+   */
+  isOpened: boolean;
+  /**
+   * Whether the user clicked the advert.
+   */
+  isClicked: boolean;
+  /**
+   * Whether the user closed the ad and has returned back to your application.
+   */
+  isClosed: boolean;
+  /**
+   * JavaScript Error containing the error code and message thrown by the Ad.
+   */
+  error?: Error;
+  /**
+   * Loaded reward item of the Rewarded Ad.
+   */
+  reward?: RewardedAdReward;
+  /**
+   * Whether the user earned the reward by Rewarded Ad.
+   */
+  isEarnedReward?: boolean;
+}
+
+export interface AdHookReturns extends AdStates {
+  /**
+   * Whether your ad is showing.
+   * The value is equal with `isOpened && !isClosed`.
+   */
+  isShowing: boolean;
+  /**
+   * Start loading the advert with the provided RequestOptions.
+   */
+  load: () => void;
+  /**
+   * Show the loaded advert to the user.
+   *
+   * @param showOptions An optional `AdShowOptions` interface.
+   */
+  show: (showOptions?: AdShowOptions) => void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,6 +1654,13 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime@^7.12.5":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.8.tgz#3e56e4aff81befa55ac3ac6a0967349fd1c5bca2"
+  integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
@@ -5154,6 +5161,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+dequal@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -11842,6 +11854,14 @@ urlgrey@1.0.0:
   integrity sha512-hJfIzMPJmI9IlLkby8QrsCykQ+SXDeO2W5Q9QTW3QpqZVTx4a/K7p8/5q+/isD8vsbVaFgql/gvAoQCRQ2Cb5w==
   dependencies:
     fast-url-parser "^1.1.3"
+
+use-deep-compare-effect@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz#ef0ce3b3271edb801da1ec23bf0754ef4189d0c6"
+  integrity sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    dequal "^2.0.2"
 
 use-subscription@^1.0.0:
   version "1.5.1"


### PR DESCRIPTION
### Description

This PR add supports for hook-style ad state management which can be used for full screen ads(AppOpen, Interstitial, Rewarded). This feature is initially implemented in another admob library, [@react-native-admob/admob](https://github.com/react-native-admob/admob).
I'm happy to join forces on this single package which can be maintained better😁.

### Related issues

### Release Summary

add full screen ad hooks

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
