### PR TITLE
feat(consent): add method that returns consent choices

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,7 @@ module.exports = {
   },
   globals: {
     __DEV__: true,
+    console: true,
     should: true,
     Utils: true,
     window: true,

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
@@ -16,11 +16,13 @@ package io.invertase.googlemobileads;
  * limitations under the License.
  *
  */
-
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.google.android.ump.ConsentDebugSettings;
@@ -28,7 +30,6 @@ import com.google.android.ump.ConsentInformation;
 import com.google.android.ump.ConsentRequestParameters;
 import com.google.android.ump.UserMessagingPlatform;
 import io.invertase.googlemobileads.common.ReactNativeModule;
-import java.util.List;
 import javax.annotation.Nonnull;
 
 public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
@@ -63,10 +64,10 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
           new ConsentDebugSettings.Builder(getApplicationContext());
 
       if (options.hasKey("testDeviceIdentifiers")) {
-        List<Object> devices = options.getArray("testDeviceIdentifiers").toArrayList();
+        ReadableArray devices = options.getArray("testDeviceIdentifiers");
 
-        for (Object device : devices) {
-          debugSettingsBuilder.addTestDeviceHashedId((String) device);
+        for (int i = 0; i < devices.size(); i++) {
+          debugSettingsBuilder.addTestDeviceHashedId(devices.getString(i));
         }
       }
 
@@ -151,5 +152,18 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
   @ReactMethod
   public void reset() {
     consentInformation.reset();
+  }
+
+  @ReactMethod
+  public void getTCString(Promise promise) {
+    try {
+      SharedPreferences prefs =
+          PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
+      // https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#in-app-details
+      String tcString = prefs.getString("IABTCF_TCString", null);
+      promise.resolve(tcString);
+    } catch (Exception e) {
+      rejectPromiseWithCodeAndMessage(promise, "consent-string-error", e.toString());
+    }
   }
 }

--- a/docs/common-reasons-for-ads-not-showing.mdx
+++ b/docs/common-reasons-for-ads-not-showing.mdx
@@ -13,6 +13,7 @@ You'll be notified of approval or rejection via email after review.
 
 New apps and ad units take some time to activate.
 Here are common reasons you may not see live impressions immediately:
+
 - It usually takes at least an hour after you create an app or ad unit
 - Sometimes it can take a few days for ads to appear in new apps or ad units
 - New iOS apps will not show Google ads until they’re listed in the Apple App Store
@@ -35,6 +36,7 @@ Test devices can either be added in the AdMob UI or programmatically using the G
 Follow the steps below to add your device as a test device.
 
 #### Add your test device in the AdMob UI
+
 For a simple, non-programmatic way to add a test device and test new or existing app builds, use the AdMob UI.
 [Learn how](https://support.google.com/admob/answer/9691433).
 
@@ -48,39 +50,39 @@ If you want to test ads in your app as you're developing, follow the steps below
 
 3. Check the console for a message that looks like this:
 
-    ```
-    GADMobileAds.sharedInstance.requestConfiguration.testDeviceIdentifiers = 
-      @[ @"2077ef9a63d2b398840261c8221a0c9b"  ]; // Sample device ID
-    ```
+   ```
+   GADMobileAds.sharedInstance.requestConfiguration.testDeviceIdentifiers =
+     @[ @"2077ef9a63d2b398840261c8221a0c9b"  ]; // Sample device ID
+   ```
 
-    Copy your test device ID to your clipboard.
+   Copy your test device ID to your clipboard.
 
 4. Check the logcat output for a message that looks like the one below, which shows you your device ID and how to add it as a test device:
 
-    ```
-    I/Ads: Use RequestConfiguration.Builder.setTestDeviceIds(Arrays.asList("33BE2250B43518CCDA7DE426D04EE231"))
-    to get test ads on this device."
-    ```
+   ```
+   I/Ads: Use RequestConfiguration.Builder.setTestDeviceIds(Arrays.asList("33BE2250B43518CCDA7DE426D04EE231"))
+   to get test ads on this device."
+   ```
 
-    Copy your test device ID to your clipboard.
+   Copy your test device ID to your clipboard.
 
 5. Modify your code to set the test device ID through testDeviceIdentifiers
 
-    ```js
-    import mobileAds from 'react-native-google-mobile-ads';
+   ```js
+   import mobileAds from 'react-native-google-mobile-ads';
 
-    mobileAds()
-      .setRequestConfiguration({
-        // An array of test device IDs to add to the allow list.
-        testDeviceIdentifiers: ["2077ef9a63d2b398840261c8221a0c9b", "EMULATOR"]
-      })
-      .then(() => {
-        // Request config successfully set!
-      });
-    ```
+   mobileAds()
+     .setRequestConfiguration({
+       // An array of test device IDs to add to the allow list.
+       testDeviceIdentifiers: ['2077ef9a63d2b398840261c8221a0c9b', 'EMULATOR'],
+     })
+     .then(() => {
+       // Request config successfully set!
+     });
+   ```
 
-5. Re-run your app. If the ad is a Google ad, you'll see a Test Ad label centered at the top of the ad.
-Ads with this Test Ad label are safe to click. Requests, impressions, and clicks on test ads will not show up in your account's reports.
+6. Re-run your app. If the ad is a Google ad, you'll see a Test Ad label centered at the top of the ad.
+   Ads with this Test Ad label are safe to click. Requests, impressions, and clicks on test ads will not show up in your account's reports.
 
 ## Emulator vs real device
 

--- a/docs/displaying-ads.mdx
+++ b/docs/displaying-ads.mdx
@@ -27,11 +27,10 @@ const appOpenAd = AppOpenAd.createForAdRequest(adUnitId, {
 });
 
 // Preload an app open ad
-appOpenAd.load()
+appOpenAd.load();
 
 // Show the app open ad when user brings the app to the foreground.
-appOpenAd.show()
-
+appOpenAd.show();
 ```
 
 ### Consider ad expiration

--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -100,6 +100,38 @@ if (consentInfo.isConsentFormAvailable && consentInfo.status === AdsConsentStatu
 
 > Do not persist the status. You could however store this locally in application state (e.g. React Context) and update the status on every app launch as it may change.
 
+### Inspecting consent choices
+
+The AdsConsentStatus tells you if you should show the modal to a user or not. Often times you want to run logic based on the user's choices though.
+Especially since the Google Mobile Ads SDK won't show any ads if the user didn't give consent to store and/or access information on the device.
+This library exports a method that returns some of the most relevant consent flags to handle common use cases.
+
+```js
+import { AdsConsent } from 'react-native-google-mobile-ads';
+
+const {
+  activelyScanDeviceCharacteristicsForIdentification,
+  applyMarketResearchToGenerateAudienceInsights,
+  createAPersonalisedAdsProfile,
+  createAPersonalisedContentProfile,
+  developAndImproveProducts,
+  measureAdPerformance,
+  measureContentPerformance,
+  selectBasicAds,
+  selectPersonalisedAds,
+  selectPersonalisedContent,
+  storeAndAccessInformationOnDevice,
+  usePreciseGeolocationData,
+} = await AdsConsent.getUserChoices();
+
+if (storeAndAccessInformationOnDevice === false) {
+  /**
+   * The user declined consent for purpose 1,
+   * the Google Mobile Ads SDK won't serve ads.
+   */
+}
+```
+
 ### Testing
 
 When developing the consent flow, the behavior of the `AdsConsent` responses may not be reliable due to the environment

--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -93,10 +93,7 @@ import { AdsConsent, AdsConsentStatus } from 'react-native-google-mobile-ads';
 
 const consentInfo = await AdsConsent.requestInfoUpdate();
 
-if (
-  consentInfo.isConsentFormAvailable &&
-  consentInfo.status === AdsConsentStatus.REQUIRED
-) {
+if (consentInfo.isConsentFormAvailable && consentInfo.status === AdsConsentStatus.REQUIRED) {
   const { status } = await AdsConsent.showForm();
 }
 ```
@@ -136,5 +133,5 @@ It is possible to reset the UMP state for test devices. To reset the ATT state y
 ```js
 import { AdsConsent } from 'react-native-google-mobile-ads';
 
-AdsConsent.reset()
+AdsConsent.reset();
 ```

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,7 +14,7 @@ a [Google AdMob account](https://apps.admob.com) is required.
 
 <YouTube id="9qCxo0D-Sak" />
 
-The module supports three types of Ads:
+The module supports four types of Ads:
 
 1. Full screen [App Open Ads](/displaying-ads#app-open-ads).
 2. Full screen [Interstitial Ads](/displaying-ads#interstitial-ads).
@@ -94,7 +94,7 @@ mobileAds()
     tagForUnderAgeOfConsent: true,
 
     // An array of test device IDs to allow.
-    testDeviceIdentifiers: ["EMULATOR"]
+    testDeviceIdentifiers: ['EMULATOR'],
   })
   .then(() => {
     // Request config successfully set!
@@ -109,14 +109,14 @@ Before loading ads, have your app initialize the Google Mobile Ads SDK by callin
 This needs to be done only once, ideally at app launch.
 
 > ⚠️ **Warning:** Ads may be preloaded by the Mobile Ads SDK or mediation partner SDKs upon calling `initialize`.
-If you need to obtain consent from users in the European Economic Area (EEA), set any request-specific flags (such as tagForChildDirectedTreatment), or otherwise take action before loading ads, ensure you do so before initializing the Mobile Ads SDK.
+> If you need to obtain consent from users in the European Economic Area (EEA), set any request-specific flags (such as tagForChildDirectedTreatment), or otherwise take action before loading ads, ensure you do so before initializing the Mobile Ads SDK.
 
 ```js
 import mobileAds from 'react-native-google-mobile-ads';
 
 mobileAds()
   .initialize()
-  .then((adapterStatuses) => {
+  .then(adapterStatuses => {
     // Initialization complete!
   });
 ```

--- a/docs/migrating-to-v5.mdx
+++ b/docs/migrating-to-v5.mdx
@@ -15,11 +15,11 @@ Previously it was possible to request the ad providers and to update the consent
 Also, while the old Consent SDK provided information about user preferences, the new `AdsConsentStatus` only tells you if you should show the modal to a user or not.
 You can read the `IABTCF_TCString` key from standardUserDefaults / SharedPreferences and decode it with a library like [@iabtcf/core](https://github.com/InteractiveAdvertisingBureau/iabtcf-es/tree/master/modules/core#iabtcfcore) though.
 
-* `requestInfoUpdate` does now accept an optional `AdsConsentInfoOptions` object instead of expecting `publisherIds` and returns a changed `AdsConsentInfo` interface
-* `showForm` does not expect any parameters any longer and now only returns the changed `AdsConsentStatus` as part of it's `AdsConsentFormResult` interface
-* `getAdProviders`, `getStatus` and `setStatus` methods were removed without replacements
-* `addTestDevices`, `setDebugGeography` and `setTagForUnderAgeOfConsent` methods were removed, but their functionality is available via `AdsConsentInfoOptions`
-* the `user_tracking_usage_description` key is needed in your project's `app.json` if you want to handle Apple's App Tracking Transparency
+- `requestInfoUpdate` does now accept an optional `AdsConsentInfoOptions` object instead of expecting `publisherIds` and returns a changed `AdsConsentInfo` interface
+- `showForm` does not expect any parameters any longer and now only returns the changed `AdsConsentStatus` as part of it's `AdsConsentFormResult` interface
+- `getAdProviders`, `getStatus` and `setStatus` methods were removed without replacements
+- `addTestDevices`, `setDebugGeography` and `setTagForUnderAgeOfConsent` methods were removed, but their functionality is available via `AdsConsentInfoOptions`
+- the `user_tracking_usage_description` key is needed in your project's `app.json` if you want to handle Apple's App Tracking Transparency
 
 ```diff
  {
@@ -33,10 +33,10 @@ You can read the `IABTCF_TCString` key from standardUserDefaults / SharedPrefere
 
 ```diff
  import { AdsConsent, AdsConsentStatus } from 'react-native-google-mobile-ads';
- 
+
 -const consentInfo = await AdsConsent.requestInfoUpdate(['pub-6189033257628123']);
 +const consentInfo = await AdsConsent.requestInfoUpdate();
- 
+
  if (
 -  consentInfo.isRequestLocationInEeaOrUnknown &&
 +  consentInfo.isConsentFormAvailable &&

--- a/docs/migrating-to-v5.mdx
+++ b/docs/migrating-to-v5.mdx
@@ -13,13 +13,13 @@ Please refer to the following links for more information:
 
 Previously it was possible to request the ad providers and to update the consent status. This is no longer the case.
 Also, while the old Consent SDK provided information about user preferences, the new `AdsConsentStatus` only tells you if you should show the modal to a user or not.
-You can read the `IABTCF_TCString` key from standardUserDefaults / SharedPreferences and decode it with a library like [@iabtcf/core](https://github.com/InteractiveAdvertisingBureau/iabtcf-es/tree/master/modules/core#iabtcfcore) though.
 
 - `requestInfoUpdate` does now accept an optional `AdsConsentInfoOptions` object instead of expecting `publisherIds` and returns a changed `AdsConsentInfo` interface
 - `showForm` does not expect any parameters any longer and now only returns the changed `AdsConsentStatus` as part of it's `AdsConsentFormResult` interface
 - `getAdProviders`, `getStatus` and `setStatus` methods were removed without replacements
 - `addTestDevices`, `setDebugGeography` and `setTagForUnderAgeOfConsent` methods were removed, but their functionality is available via `AdsConsentInfoOptions`
 - the `user_tracking_usage_description` key is needed in your project's `app.json` if you want to handle Apple's App Tracking Transparency
+- newly added `getUserChoices` can be used to inspect some of the consent choices
 
 ```diff
  {
@@ -50,5 +50,14 @@ You can read the `IABTCF_TCString` key from standardUserDefaults / SharedPrefere
 -    withAdFree: true,
 -  });
 +  const formResult = await AdsConsent.showForm()
++
++  const { storeAndAccessInformationOnDevice } = await AdsConsent.getUserChoices();
++
++  if (storeAndAccessInformationOnDevice === false) {
++    /**
++     * The user declined consent for purpose 1,
++     * the Google Mobile Ads SDK won't serve ads.
++     */
++  }
  }
 ```

--- a/e2e/consent.e2e.js
+++ b/e2e/consent.e2e.js
@@ -94,6 +94,14 @@ describe('googleAds AdsConsent', function () {
     });
   });
 
+  describe('getUserChoices', function () {
+    it('returns consent choices', async function () {
+      const choices = await AdsConsent.getUserChoices();
+      choices.storeAndAccessInformationOnDevice.should.be.Boolean();
+      choices.usePreciseGeolocationData.should.be.Boolean();
+    });
+  });
+
   describe('reset', function () {
     it('resets', function () {
       AdsConsent.reset();

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -11,10 +11,9 @@ import {
 import {Test, TestRegistry, TestResult, TestRunner, TestType} from 'jet';
 
 import {
+  AdEventType,
   AdsConsent,
   AdsConsentDebugGeography,
-  AdsConsentStatus,
-  AdEventType,
   AppOpenAd,
   InterstitialAd,
   TestIds,
@@ -253,11 +252,12 @@ class AdConsentTest implements Test {
               testDeviceIdentifiers: [],
             });
 
-            if (
-              consentInfo.isConsentFormAvailable &&
-              consentInfo.status === AdsConsentStatus.REQUIRED
-            ) {
+            if (consentInfo.isConsentFormAvailable) {
               await AdsConsent.showForm();
+
+              const choices = await AdsConsent.getUserChoices();
+
+              console.log(JSON.stringify(choices, null, 2));
             }
           }}
         />

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1095,6 +1095,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@iabtcf/core@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@iabtcf/core/-/core-1.4.0.tgz#b5cd782ba86da44efaad8f26c909ec6ea68dc799"
+  integrity sha512-LfyscG/rNhw542MX4pNSBPzK3ddHDYB8cz7pNTOI6D664x7jJmVZjkRmw8X/h9yGQ2c0a/1AP9F8n5/UsxKjeA==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
@@ -121,4 +121,18 @@ RCT_EXPORT_METHOD(showForm : (RCTPromiseResolveBlock)resolve : (RCTPromiseReject
 
 RCT_EXPORT_METHOD(reset) { [UMPConsentInformation.sharedInstance reset]; }
 
+RCT_EXPORT_METHOD(getTCString : (RCTPromiseResolveBlock)resolve : (RCTPromiseRejectBlock)reject) {
+  @try {
+    // https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#in-app-details
+    NSString *tcString = [[NSUserDefaults standardUserDefaults] objectForKey:@"IABTCF_TCString"];
+    resolve(tcString);
+  } @catch (NSError *error) {
+    [RNSharedUtils rejectPromiseWithUserInfo:reject
+                                    userInfo:[@{
+                                      @"code" : @"consent-string-error",
+                                      @"message" : error.localizedDescription,
+                                    } mutableCopy]];
+  }
+}
+
 @end

--- a/package.json
+++ b/package.json
@@ -98,6 +98,10 @@
     "tests:ios:test-cover-reuse": "cd example && node_modules/.bin/nyc yarn detox test --configuration ios.sim.debug --reuse --loglevel warn",
     "tests:ios:pod:install": "cd example && cd ios && rm -rf example.xcworkspace && rm -f Podfile.lock && pod install --repo-update && cd .."
   },
+  "dependencies": {
+    "@iabtcf/core": "^1.4.0",
+    "use-deep-compare-effect": "^1.8.1"
+  },
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.16.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lint:ios:check": "clang-format --glob=\"ios/**/*.{h,cpp,m,mm}\" --style=Google -n -Werror",
     "lint:ios:fix": "clang-format -i --glob=\"ios/**/*.{h,cpp,m,mm}\" --style=Google",
     "lint:markdown:check": "prettier --check \"docs/**/*.md[x]\"",
-    "lint:markdown:fix": "prettier --write \"docs/**/*.md\"",
+    "lint:markdown:fix": "prettier --write \"docs/**/*.md[x]\"",
     "lint:report": "eslint --output-file=eslint-report.json --format=json . --ext .js,.jsx,.ts,.tsx",
     "lint:spellcheck": "spellchecker --quiet --files=\"docs/**/*.md\" --dictionaries=\"./.spellcheck.dict.txt\" --reports=\"spelling.json\" --plugins spell indefinite-article repeated-words syntax-mentions syntax-urls frontmatter",
     "tsc:compile": "tsc --project . --noEmit",
@@ -141,8 +141,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "use-deep-compare-effect": "^1.8.1"
   }
 }

--- a/src/AdsConsentPurposes.ts
+++ b/src/AdsConsentPurposes.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ *
+ * The definitions in this document are copied from IAB's global vendor list.
+ *
+ *   https://vendor-list.consensu.org/v2/vendor-list.json
+ *   https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework
+ *
+ */
+
+export enum AdsConsentPurposes {
+  /**
+   * Cookies, device identifiers, or other information can be stored or
+   * accessed on your device for the purposes presented to you.
+   *
+   * Vendors can:
+   *   - Store and access information on the device such as cookies
+   *     and device identifiers presented to a user.
+   */
+  STORE_AND_ACCESS_INFORMATION_ON_DEVICE = 1,
+
+  /**
+   * Ads can be shown to you based on the content you’re viewing,
+   * the app you’re using, your approximate location, or your device type.
+   *
+   * To do basic ad selection vendors can:
+   *  - Use real-time information about the context in which the ad will be shown,
+   *    to show the ad, including information about the content and the device, such as:
+   *    device type and capabilities, user agent, URL, IP address
+   *  - Use a user’s non-precise geolocation data
+   *  - Control the frequency of ads shown to a user.
+   *  - Sequence the order in which ads are shown to a user.
+   *  - Prevent an ad from serving in an unsuitable editorial (brand-unsafe) context
+   *
+   * Vendors cannot:
+   *  - Create a personalised ads profile using this information for the selection of
+   *    future ads without a separate legal basis to create a personalised ads profile.
+   *  - N.B. Non-precise means only an approximate location involving at least a radius
+   *    of 500 meters is permitted.
+   */
+  SELECT_BASIC_ADS = 2,
+
+  /**
+   * A profile can be built about you and your interests to show you personalised ads
+   * that are relevant to you.
+   *
+   * To create a personalised ads profile vendors can:
+   *   - Collect information about a user, including a user's activity, interests,
+   *     demographic information, or location, to create or edit a user profile for use
+   *     in personalised advertising.
+   *   - Combine this information with other information previously collected,
+   *     including from across websites and apps, to create or edit a user profile
+   *     for use in personalised advertising.
+   */
+  CREATE_A_PERSONALISED_ADS_PROFILE = 3,
+
+  /**
+   * Personalised ads can be shown to you based on a profile about you.
+   *
+   * To select personalised ads vendors can:
+   *   - Select personalised ads based on a user profile or other historical user data,
+   *     including a user’s prior activity, interests, visits to sites or apps, location,
+   *     or demographic information.
+   */
+  SELECT_PERSONALISED_ADS = 4,
+
+  /**
+   * A profile can be built about you and your interests to show you personalised content
+   * that is relevant to you.
+   *
+   * To create a personalised content profile vendors can:
+   *   - Collect information about a user, including a user's activity, interests, visits to
+   *     sites or apps, demographic information, or location, to create or edit a user profile
+   *     for personalising content.
+   *   - Combine this information with other information previously collected,
+   *     including from across websites and apps, to create or edit a user profile for use
+   *     in personalising content.
+   */
+  CREATE_A_PERSONALISED_CONTENT_PROFILE = 5,
+
+  /**
+   * Personalised content can be shown to you based on a profile about you.
+   *
+   * To select personalised content vendors can:
+   *   - Select personalised content based on a user profile or other historical user data,
+   *     including a user’s prior activity, interests, visits to sites or apps, location,
+   *     or demographic information.
+   */
+  SELECT_PERSONALISED_CONTENT = 6,
+
+  /**
+   * The performance and effectiveness of ads that you see or interact with can be measured.
+   *
+   * To measure ad performance vendors can:
+   *   - Measure whether and how ads were delivered to and interacted with by a user
+   *   - Provide reporting about ads including their effectiveness and performance
+   *   - Provide reporting about users who interacted with ads using data observed during
+   *     the course of the user's interaction with that ad
+   *   - Provide reporting to publishers about the ads displayed on their property
+   *   - Measure whether an ad is serving in a suitable editorial environment (brand-safe) context
+   *   - Determine the percentage of the ad that had the opportunity to be seen and
+   *     the duration of that opportunity
+   *   - Combine this information with other information previously collected,
+   *     including from across websites and apps
+   *
+   * Vendors cannot:
+   *   - Apply panel- or similarly-derived audience insights data to ad measurement data
+   *     without a Legal Basis to apply market research to generate audience insights (Purpose 9)
+   */
+  MEASURE_AD_PERFORMANCE = 7,
+
+  /**
+   * The performance and effectiveness of content that you see or interact with can be measured.
+   *
+   * To measure content performance vendors can:
+   *   - Measure and report on how content was delivered to and interacted with by users.
+   *   - Provide reporting, using directly measurable or known information, about users who
+   *     interacted with the content
+   *   - Combine this information with other information previously collected,
+   *     including from across websites and apps.
+   *
+   * Vendors cannot:
+   *   - Measure whether and how ads (including native ads) were delivered to and
+   *     interacted with by a user.
+   *   - Apply panel- or similarly derived audience insights data to ad measurement
+   *     data without a Legal Basis to apply market research to generate audience insights (Purpose 9)
+   */
+  MEASURE_CONTENT_PERFORMANCE = 8,
+
+  /**
+   * Market research can be used to learn more about the audiences who visit sites/apps and view ads.
+   *
+   * To apply market research to generate audience insights vendors can:
+   *   - Provide aggregate reporting to advertisers or their representatives about
+   *     the audiences reached by their ads, through panel-based and similarly derived insights.
+   *   - Provide aggregate reporting to publishers about the audiences that were served or
+   *     interacted with content and/or ads on their property by applying
+   *     panel-based and similarly derived insights.
+   *   - Associate offline data with an online user for the purposes of
+   *     market research to generate audience insights if vendors have declared to match and
+   *     combine offline data sources (Feature 1)
+   *   - Combine this information with other information previously collected including from
+   *     across websites and apps.
+   *
+   * Vendors cannot:
+   *   - Measure the performance and effectiveness of ads that a specific user was served or
+   *     interacted with, without a Legal Basis to measure ad performance.
+   *   - Measure which content a specific user was served and how they interacted with it,
+   *     without a Legal Basis to measure content performance.
+   */
+  APPLY_MARKET_RESEARCH_TO_GENERATE_AUDIENCE_INSIGHTS = 9,
+
+  /**
+   * Your data can be used to improve existing systems and software,
+   * and to develop new products
+   *
+   * To develop new products and improve products vendors can:
+   *   - Use information to improve their existing products with new features and
+   *     to develop new products
+   *   - Create new models and algorithms through machine learning
+   *
+   * Vendors cannot:
+   *   - Conduct any other data processing operation allowed under
+   *     a different purpose under this purpose
+   */
+  DEVELOP_AND_IMPROVE_PRODUCTS = 10,
+}

--- a/src/AdsConsentSpecialFeatures.ts
+++ b/src/AdsConsentSpecialFeatures.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ *
+ * The definitions in this document are copied from IAB's global vendor list.
+ *
+ *   https://vendor-list.consensu.org/v2/vendor-list.json
+ *   https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework
+ *
+ */
+
+export enum AdsConsentSpecialFeatures {
+  /**
+   * Your precise geolocation data can be used in support of one or more purposes.
+   * This means your location can be accurate to within several meters.
+   *
+   * Vendors can:
+   *   - Collect and process precise geolocation data in support of one or more purposes.
+   *   - Precise geolocation means that there are no restrictions on the precision of
+   *     a user's location; this can be accurate to within several meters.
+   */
+  USE_PRECISE_GEOLOCATION_DATA = 1,
+
+  /**
+   * Your device can be identified based on a scan of your device's
+   * unique combination of characteristics.
+   *
+   * Vendors can:
+   *   - Create an identifier using data collected via actively scanning a device for
+   *     specific characteristics, e.g. installed fonts or screen resolution.
+   *   - Use such an identifier to re-identify a device.
+   */
+  ACTIVELY_SCAN_DEVICE_CHARACTERISTICS_FOR_IDENTIFICATION = 2,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export const SDK_VERSION = version;
 
 export { default, MobileAds } from './MobileAds';
 export { AdsConsentDebugGeography } from './AdsConsentDebugGeography';
+export { AdsConsentPurposes } from './AdsConsentPurposes';
+export { AdsConsentSpecialFeatures } from './AdsConsentSpecialFeatures';
 export { AdsConsentStatus } from './AdsConsentStatus';
 export { MaxAdContentRating } from './MaxAdContentRating';
 export { TestIds } from './TestIds';

--- a/src/types/AdsConsent.interface.ts
+++ b/src/types/AdsConsent.interface.ts
@@ -1,3 +1,4 @@
+import { TCModel } from '@iabtcf/core';
 import { AdsConsentDebugGeography } from '../AdsConsentDebugGeography';
 import { AdsConsentStatus } from '../AdsConsentStatus';
 
@@ -58,6 +59,50 @@ export interface AdsConsentInterface {
    * ```
    */
   showForm(): Promise<AdsConsentFormResult>;
+
+  /**
+   * Returns the value stored under the `IABTCF_TCString` key
+   * in NSUserDefaults (iOS) / SharedPreferences (Android) as
+   * defined by the IAB Europe Transparency & Consent Framework.
+   *
+   * More information available here:
+   * https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#in-app-details
+   *
+   * #### Example
+   *
+   * ```js
+   * import { AdsConsent } from '@invertase/react-native-google-ads';
+   *
+   * const tcString = await AdsConsent.getTCString();
+   * ```
+   */
+  getTCString(): Promise<string>;
+
+  /**
+   * Returns the TC Model of the saved IAB TCF 2.0 String.
+   *
+   * #### Example
+   *
+   * ```js
+   * import { AdsConsent } from '@invertase/react-native-google-ads';
+   *
+   * const tcModel = await AdsConsent.getTCModel();
+   * ```
+   */
+  getTCModel(): Promise<TCModel>;
+
+  /**
+   * Provides information about a user's consent choices.
+   *
+   * #### Example
+   *
+   * ```js
+   * import { AdsConsent } from '@invertase/react-native-google-ads';
+   *
+   * const { storeAndAccessInformationOnDevice } = await AdsConsent.getUserChoices();
+   * ```
+   */
+  getUserChoices(): Promise<AdsConsentUserChoices>;
 
   /**
    * Resets the UMP SDK state.
@@ -126,4 +171,179 @@ export interface AdsConsentInfo {
    * If `true` a consent form is available.
    */
   isConsentFormAvailable: boolean;
+}
+
+/**
+ * The options used when requesting consent information.
+ *
+ * https://vendor-list.consensu.org/v2/vendor-list.json
+ * https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework
+ */
+export interface AdsConsentUserChoices {
+  /**
+   * Your device can be identified based on a scan of your device's
+   * unique combination of characteristics.
+   *
+   * Vendors can:
+   *   - Create an identifier using data collected via actively scanning a device for
+   *   - specific characteristics, e.g. installed fonts or screen resolution.
+   *   - Use such an identifier to re-identify a device.
+   */
+  activelyScanDeviceCharacteristicsForIdentification: boolean;
+  /**
+   * Market research can be used to learn more about the audiences who visit sites/apps and view ads.
+   *
+   * To apply market research to generate audience insights vendors can:
+   *   - Provide aggregate reporting to advertisers or their representatives about
+   *     the audiences reached by their ads, through panel-based and similarly derived insights.
+   *   - Provide aggregate reporting to publishers about the audiences that were served or
+   *     interacted with content and/or ads on their property by applying
+   *     panel-based and similarly derived insights.
+   *   - Associate offline data with an online user for the purposes of
+   *     market research to generate audience insights if vendors have declared to match and
+   *     combine offline data sources (Feature 1)
+   *   - Combine this information with other information previously collected including from
+   *     across websites and apps.
+   *
+   * Vendors cannot:
+   *   - Measure the performance and effectiveness of ads that a specific user was served or
+   *     interacted with, without a Legal Basis to measure ad performance.
+   *   - Measure which content a specific user was served and how they interacted with it,
+   *     without a Legal Basis to measure content performance.
+   */
+  applyMarketResearchToGenerateAudienceInsights: boolean;
+  /**
+   * A profile can be built about you and your interests to show you personalised ads
+   * that are relevant to you.
+   *
+   * To create a personalised ads profile vendors can:
+   *   - Collect information about a user, including a user's activity, interests,
+   *     demographic information, or location, to create or edit a user profile for use
+   *     in personalised advertising.
+   *   - Combine this information with other information previously collected,
+   *     including from across websites and apps, to create or edit a user profile
+   *     for use in personalised advertising.
+   */
+  createAPersonalisedAdsProfile: boolean;
+  /**
+   * A profile can be built about you and your interests to show you personalised content
+   * that is relevant to you.
+   *
+   * To create a personalised content profile vendors can:
+   *   - Collect information about a user, including a user's activity, interests, visits to
+   *     sites or apps, demographic information, or location, to create or edit a user profile
+   *     for personalising content.
+   *   - Combine this information with other information previously collected,
+   *     including from across websites and apps, to create or edit a user profile for use
+   *     in personalising content.
+   */
+  createAPersonalisedContentProfile: boolean;
+  /**
+   * Your data can be used to improve existing systems and software,
+   * and to develop new products
+   *
+   * To develop new products and improve products vendors can:
+   *   - Use information to improve their existing products with new features and
+   *     to develop new products
+   *   - Create new models and algorithms through machine learning
+   *
+   * Vendors cannot:
+   *   - Conduct any other data processing operation allowed under
+   *     a different purpose under this purpose
+   */
+  developAndImproveProducts: boolean;
+  /**
+   * The performance and effectiveness of ads that you see or interact with can be measured.
+   *
+   * To measure ad performance vendors can:
+   *   - Measure whether and how ads were delivered to and interacted with by a user
+   *   - Provide reporting about ads including their effectiveness and performance
+   *   - Provide reporting about users who interacted with ads using data observed during
+   *     the course of the user's interaction with that ad
+   *   - Provide reporting to publishers about the ads displayed on their property
+   *   - Measure whether an ad is serving in a suitable editorial environment (brand-safe) context
+   *   - Determine the percentage of the ad that had the opportunity to be seen and
+   *     the duration of that opportunity
+   *   - Combine this information with other information previously collected,
+   *     including from across websites and apps
+   *
+   * Vendors cannot:
+   *   - Apply panel- or similarly-derived audience insights data to ad measurement data
+   *     without a Legal Basis to apply market research to generate audience insights (Purpose 9)
+   */
+  measureAdPerformance: boolean;
+  /**
+   * The performance and effectiveness of content that you see or interact with can be measured.
+   *
+   * To measure content performance vendors can:
+   *   - Measure and report on how content was delivered to and interacted with by users.
+   *   - Provide reporting, using directly measurable or known information, about users who
+   *     interacted with the content
+   *   - Combine this information with other information previously collected,
+   *     including from across websites and apps.
+   *
+   * Vendors cannot:
+   *   - Measure whether and how ads (including native ads) were delivered to and
+   *     interacted with by a user.
+   *   - Apply panel- or similarly derived audience insights data to ad measurement
+   *     data without a Legal Basis to apply market research to generate audience insights (Purpose 9)
+   */
+  measureContentPerformance: boolean;
+  /**
+   * Ads can be shown to you based on the content you’re viewing,
+   * the app you’re using, your approximate location, or your device type.
+   *
+   * To do basic ad selection vendors can:
+   *  - Use real-time information about the context in which the ad will be shown,
+   *    to show the ad, including information about the content and the device, such as:
+   *    device type and capabilities, user agent, URL, IP address
+   *  - Use a user’s non-precise geolocation data
+   *  - Control the frequency of ads shown to a user.
+   *  - Sequence the order in which ads are shown to a user.
+   *  - Prevent an ad from serving in an unsuitable editorial (brand-unsafe) context
+   *
+   * Vendors cannot:
+   *  - Create a personalised ads profile using this information for the selection of
+   *    future ads without a separate legal basis to create a personalised ads profile.
+   *  - N.B. Non-precise means only an approximate location involving at least a radius
+   *    of 500 meters is permitted.
+   */
+  selectBasicAds: boolean;
+  /**
+   * Personalised ads can be shown to you based on a profile about you.
+   *
+   * To select personalised ads vendors can:
+   *   - Select personalised ads based on a user profile or other historical user data,
+   *     including a user’s prior activity, interests, visits to sites or apps, location,
+   *     or demographic information.
+   */
+  selectPersonalisedAds: boolean;
+  /**
+   * Personalised content can be shown to you based on a profile about you.
+   *
+   * To select personalised content vendors can:
+   *   - Select personalised content based on a user profile or other historical user data,
+   *     including a user’s prior activity, interests, visits to sites or apps, location,
+   *     or demographic information.
+   */
+  selectPersonalisedContent: boolean;
+  /**
+   * Cookies, device identifiers, or other information can be stored or
+   * accessed on your device for the purposes presented to you.
+   *
+   * Vendors can:
+   *   - Store and access information on the device such as cookies and
+   *     device identifiers presented to a user.
+   */
+  storeAndAccessInformationOnDevice: boolean;
+  /**
+   * Your precise geolocation data can be used in support of one or more purposes.
+   * This means your location can be accurate to within several meters.
+   *
+   * Vendors can:
+   *   - Collect and process precise geolocation data in support of one or more purposes.
+   *   - Precise geolocation means that there are no restrictions on the precision of
+   *     a user's location; this can be accurate to within several meters.
+   */
+  usePreciseGeolocationData: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1792,6 +1792,11 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
+"@iabtcf/core@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@iabtcf/core/-/core-1.4.0.tgz#b5cd782ba86da44efaad8f26c909ec6ea68dc799"
+  integrity sha512-LfyscG/rNhw542MX4pNSBPzK3ddHDYB8cz7pNTOI6D664x7jJmVZjkRmw8X/h9yGQ2c0a/1AP9F8n5/UsxKjeA==
+
 "@isaacs/string-locale-compare@^1.0.1", "@isaacs/string-locale-compare@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz#291c227e93fd407a96ecd59879a35809120e432b"


### PR DESCRIPTION
### Description

v5.0.0 introduced the UMP SDK, which stores the consent as an encoded string on the device and doesn't provide further information. It is a common use case to act upon a user's choices though, especially as the Google Mobile Ads SDK won't serve any ads if the user doesn't at least provide consent to store and/or access information on the device. This PR aims to bridge that gap by introducing a new method to the `AdsConsent` interface called `getUserChoices` (happy to hear other suggestions).

I also went ahead and replaced the JSDocs inside `src/AdsConsent.ts` with TypeScript types. If the JSDocs serve a purpose, then let me know and I'll revert.

### Related issues

Related to https://github.com/invertase/react-native-google-mobile-ads/issues/96

### Checklist

- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`
- My change includes tests;
  - [X] `e2e` tests added or updated in `__tests__e2e__`
- [X] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [X] No


