### PR TITLE
fix(ios): avoid crash on ios < 14 without AppTrackingTransparency

### DIFF
--- a/RNGoogleMobileAds.podspec
+++ b/RNGoogleMobileAds.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "10.0"
   s.source_files        = 'ios/**/*.{h,m}'
-  s.frameworks          = "AppTrackingTransparency"
+  s.weak_frameworks     = "AppTrackingTransparency"
 
   # React Native dependencies
   s.dependency          'React-Core'


### PR DESCRIPTION
### Description

AppTrackingTransparency framework only exists on iOS14+ so if we ask cocoapods to link the framework we get a crash during the link phase on ios14

Switch to "weak_frameworks" for the framework reference, and app appears to boot fine now

Thanks to @ccorneliusHsv for taking the time to report it!

### Related issues

Fixes #111 

### Release Summary


commit is conventional, semantic release should work

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

You need an iOS13 simulator to reproduce the crash, it crashes on v5.0.0 and v5.1.0
After this change and a `pod install` the example app works on the same emulator

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
