### PR TITLE
fix: fix wrong hook return type omit

### DIFF
--- a/src/hooks/useAppOpenAd.ts
+++ b/src/hooks/useAppOpenAd.ts
@@ -33,7 +33,7 @@ import { useFullScreenAd } from './useFullScreenAd';
 export function useAppOpenAd(
   adUnitId: string | null,
   requestOptions: RequestOptions = {},
-): Omit<AdHookReturns, 'adReward'> {
+): Omit<AdHookReturns, 'reward' | 'isEarnedReward'> {
   const [appOpenAd, setAppOpenAd] = useState<AppOpenAd | null>(null);
 
   useDeepCompareEffect(() => {

--- a/src/hooks/useInterstitialAd.ts
+++ b/src/hooks/useInterstitialAd.ts
@@ -33,7 +33,7 @@ import { useFullScreenAd } from './useFullScreenAd';
 export function useInterstitialAd(
   adUnitId: string | null,
   requestOptions: RequestOptions = {},
-): Omit<AdHookReturns, 'adReward'> {
+): Omit<AdHookReturns, 'reward' | 'isEarnedReward'> {
   const [interstitialAd, setInterstitialAd] = useState<InterstitialAd | null>(null);
 
   useDeepCompareEffect(() => {


### PR DESCRIPTION
### Description

Fixes wrong type omit in full screen ad hooks.

### Related issues

### Release Summary

fix wrong hook return type 

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
