### PR TITLE
refactor: move common ad logics to mobilead class

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.java
@@ -119,7 +119,8 @@ public class ReactNativeGoogleMobileAdsAppOpenModule extends ReactNativeModule {
   }
 
   @ReactMethod
-  public void appOpenShow(int requestId, ReadableMap showOptions, Promise promise) {
+  public void appOpenShow(
+      int requestId, String adUnitId, ReadableMap showOptions, Promise promise) {
     if (getCurrentActivity() == null) {
       rejectPromiseWithCodeAndMessage(
           promise,

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.java
@@ -120,7 +120,8 @@ public class ReactNativeGoogleMobileAdsInterstitialModule extends ReactNativeMod
   }
 
   @ReactMethod
-  public void interstitialShow(int requestId, ReadableMap showOptions, Promise promise) {
+  public void interstitialShow(
+      int requestId, String adUnitId, ReadableMap showOptions, Promise promise) {
     if (getCurrentActivity() == null) {
       rejectPromiseWithCodeAndMessage(
           promise,

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.m
@@ -77,6 +77,7 @@ RCT_EXPORT_METHOD(appOpenLoad
 
 RCT_EXPORT_METHOD(appOpenShow
                   : (nonnull NSNumber *)requestId
+                  : (NSString *)adUnitId
                   : (NSDictionary *)showOptions
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.m
@@ -102,6 +102,7 @@ RCT_EXPORT_METHOD(interstitialLoad
 
 RCT_EXPORT_METHOD(interstitialShow
                   : (nonnull NSNumber *)requestId
+                  : (NSString *)adUnitId
                   : (NSDictionary *)showOptions
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {

--- a/src/ads/AppOpenAd.ts
+++ b/src/ads/AppOpenAd.ts
@@ -18,19 +18,16 @@
 import { isString } from '../common';
 import { MobileAds } from '../MobileAds';
 import { validateAdRequestOptions } from '../validateAdRequestOptions';
-import { validateAdShowOptions } from '../validateAdShowOptions';
 import { MobileAd } from './MobileAd';
 import { AdEventType } from '../AdEventType';
 import { AdEventListener } from '../types/AdEventListener';
 import { AdEventsListener } from '../types/AdEventsListener';
-import { AdShowOptions } from '../types/AdShowOptions';
 import { RequestOptions } from '../types/RequestOptions';
-import { MobileAdInterface } from '../types/MobileAd.interface';
 
-let _appOpenRequest = 0;
+export class AppOpenAd extends MobileAd {
+  protected static _appOpenRequest = 0;
 
-export class AppOpenAd extends MobileAd implements MobileAdInterface {
-  static createForAdRequest(adUnitId: string, requestOptions?: RequestOptions): AppOpenAd {
+  static createForAdRequest(adUnitId: string, requestOptions?: RequestOptions) {
     if (!isString(adUnitId)) {
       throw new Error("AppOpenAd.createForAdRequest(*) 'adUnitId' expected an string value.");
     }
@@ -44,37 +41,8 @@ export class AppOpenAd extends MobileAd implements MobileAdInterface {
       }
     }
 
-    const requestId = _appOpenRequest++;
+    const requestId = AppOpenAd._appOpenRequest++;
     return new AppOpenAd('app_open', MobileAds(), requestId, adUnitId, options);
-  }
-
-  load() {
-    // Prevent multiple load calls
-    if (this._loaded || this._isLoadCalled) {
-      return;
-    }
-
-    this._isLoadCalled = true;
-    this._googleMobileAds.native.appOpenLoad(this._requestId, this._adUnitId, this._requestOptions);
-  }
-
-  show(showOptions?: AdShowOptions) {
-    if (!this._loaded) {
-      throw new Error(
-        'AppOpenAd.show() The requested AppOpenAd has not loaded and could not be shown.',
-      );
-    }
-
-    let options;
-    try {
-      options = validateAdShowOptions(showOptions);
-    } catch (e) {
-      if (e instanceof Error) {
-        throw new Error(`AppOpenAd.show(*) ${e.message}.`);
-      }
-    }
-
-    return this._googleMobileAds.native.appOpenShow(this._requestId, options);
   }
 
   addAdEventsListener<T extends AdEventType>(listener: AdEventsListener<T>): () => void {

--- a/src/ads/InterstitialAd.ts
+++ b/src/ads/InterstitialAd.ts
@@ -18,16 +18,11 @@
 import { isString } from '../common';
 import { MobileAds } from '../MobileAds';
 import { validateAdRequestOptions } from '../validateAdRequestOptions';
-import { validateAdShowOptions } from '../validateAdShowOptions';
 import { MobileAd } from './MobileAd';
 import { AdEventType } from '../AdEventType';
 import { AdEventListener } from '../types/AdEventListener';
 import { AdEventsListener } from '../types/AdEventsListener';
-import { AdShowOptions } from '../types/AdShowOptions';
 import { RequestOptions } from '../types/RequestOptions';
-import { MobileAdInterface } from '../types/MobileAd.interface';
-
-let _interstitialRequest = 0;
 
 /**
  * A class for interacting and showing Interstitial Ads.
@@ -68,7 +63,8 @@ let _interstitialRequest = 0;
  * The advert will be presented to the user, and several more events can be triggered such as the user clicking the
  * advert or closing it.
  */
-export class InterstitialAd extends MobileAd implements MobileAdInterface {
+export class InterstitialAd extends MobileAd {
+  protected static _interstitialRequest = 0;
   /**
    * Creates a new InterstitialAd instance.
    *
@@ -91,7 +87,7 @@ export class InterstitialAd extends MobileAd implements MobileAdInterface {
    * @param adUnitId The Ad Unit ID for the Interstitial. You can find this on your Google Mobile Ads dashboard.
    * @param requestOptions Optional RequestOptions used to load the ad.
    */
-  static createForAdRequest(adUnitId: string, requestOptions?: RequestOptions): InterstitialAd {
+  static createForAdRequest(adUnitId: string, requestOptions?: RequestOptions) {
     if (!isString(adUnitId)) {
       throw new Error("InterstitialAd.createForAdRequest(*) 'adUnitId' expected an string value.");
     }
@@ -105,41 +101,8 @@ export class InterstitialAd extends MobileAd implements MobileAdInterface {
       }
     }
 
-    const requestId = _interstitialRequest++;
+    const requestId = InterstitialAd._interstitialRequest++;
     return new InterstitialAd('interstitial', MobileAds(), requestId, adUnitId, options);
-  }
-
-  load() {
-    // Prevent multiple load calls
-    if (this._loaded || this._isLoadCalled) {
-      return;
-    }
-
-    this._isLoadCalled = true;
-    this._googleMobileAds.native.interstitialLoad(
-      this._requestId,
-      this._adUnitId,
-      this._requestOptions,
-    );
-  }
-
-  show(showOptions?: AdShowOptions) {
-    if (!this._loaded) {
-      throw new Error(
-        'InterstitialAd.show() The requested InterstitialAd has not loaded and could not be shown.',
-      );
-    }
-
-    let options;
-    try {
-      options = validateAdShowOptions(showOptions);
-    } catch (e) {
-      if (e instanceof Error) {
-        throw new Error(`InterstitialAd.show(*) ${e.message}.`);
-      }
-    }
-
-    return this._googleMobileAds.native.interstitialShow(this._requestId, options);
   }
 
   addAdEventsListener<T extends AdEventType>(listener: AdEventsListener<T>) {

--- a/src/ads/MobileAd.ts
+++ b/src/ads/MobileAd.ts
@@ -22,13 +22,16 @@ import { AdEventType } from '../AdEventType';
 import { RewardedAdEventType } from '../RewardedAdEventType';
 import { AdEventListener, AdEventPayload } from '../types/AdEventListener';
 import { AdEventsListener } from '../types/AdEventsListener';
+import { AdShowOptions } from '../types/AdShowOptions';
 import { RequestOptions } from '../types/RequestOptions';
+import { MobileAdInterface } from '../types/MobileAd.interface';
 import { MobileAdsModuleInterface } from '../types/MobileAdsModule.interface';
 import { RewardedAdReward } from '../types/RewardedAdReward';
+import { validateAdShowOptions } from '../validateAdShowOptions';
 
 type EventType = AdEventType | RewardedAdEventType;
 
-export class MobileAd {
+export abstract class MobileAd implements MobileAdInterface {
   protected _type: 'app_open' | 'interstitial' | 'rewarded';
   protected _googleMobileAds: MobileAdsModuleInterface;
   protected _requestId: number;
@@ -110,9 +113,7 @@ export class MobileAd {
 
   protected _addAdEventsListener<T extends EventType>(listener: AdEventsListener<T>) {
     if (!isFunction(listener)) {
-      throw new Error(
-        `${this.constructor.name}.addAdEventsListener(*) 'listener' expected a function.`,
-      );
+      throw new Error(`${this._className}.addAdEventsListener(*) 'listener' expected a function.`);
     }
 
     const id = this._adEventsListenerId++;
@@ -130,12 +131,12 @@ export class MobileAd {
       )
     ) {
       throw new Error(
-        `${this.constructor.name}.addAdEventListener(*) 'type' expected a valid event type value.`,
+        `${this._className}.addAdEventListener(*) 'type' expected a valid event type value.`,
       );
     }
     if (!isFunction(listener)) {
       throw new Error(
-        `${this.constructor.name}.addAdEventListener(_, *) 'listener' expected a function.`,
+        `${this._className}.addAdEventListener(_, *) 'listener' expected a function.`,
       );
     }
 
@@ -150,18 +151,61 @@ export class MobileAd {
     return this._adEventListenersMap.get(type) as Map<number, AdEventListener<T>>;
   }
 
-  removeAllListeners() {
+  protected get _className() {
+    return this.constructor.name;
+  }
+
+  public load() {
+    // Prevent multiple load calls
+    if (this._loaded || this._isLoadCalled) {
+      return;
+    }
+
+    this._isLoadCalled = true;
+    const type = this._type === 'app_open' ? 'appOpen' : this._type;
+    const load = this._googleMobileAds.native[`${type}Load`];
+    load(this._requestId, this._adUnitId, this._requestOptions);
+  }
+
+  public show(showOptions?: AdShowOptions) {
+    if (!this._loaded) {
+      throw new Error(
+        `${this._className}.show() The requested ${this._className} has not loaded and could not be shown.`,
+      );
+    }
+
+    let options;
+    try {
+      options = validateAdShowOptions(showOptions);
+    } catch (e) {
+      if (e instanceof Error) {
+        throw new Error(`${this._className}.show(*) ${e.message}.`);
+      } else {
+        throw e;
+      }
+    }
+
+    const type = this._type === 'app_open' ? 'appOpen' : this._type;
+    const show = this._googleMobileAds.native[`${type}Show`];
+    return show(this._requestId, this._adUnitId, options);
+  }
+
+  public abstract addAdEventsListener<T extends never>(listener: AdEventsListener<T>): () => void;
+
+  public abstract addAdEventListener<T extends never>(type: T, listener: AdEventListener<T>): void;
+
+  public removeAllListeners() {
     this._adEventsListeners.clear();
     this._adEventListenersMap.forEach((_, type, map) => {
       map.set(type, new Map());
     });
   }
 
-  get adUnitId() {
+  public get adUnitId() {
     return this._adUnitId;
   }
 
-  get loaded() {
+  public get loaded() {
     return this._loaded;
   }
 }

--- a/src/ads/RewardedAd.ts
+++ b/src/ads/RewardedAd.ts
@@ -18,17 +18,12 @@
 import { isString } from '../common';
 import { MobileAds } from '../MobileAds';
 import { validateAdRequestOptions } from '../validateAdRequestOptions';
-import { validateAdShowOptions } from '../validateAdShowOptions';
 import { MobileAd } from './MobileAd';
 import { AdEventType } from '../AdEventType';
 import { RewardedAdEventType } from '../RewardedAdEventType';
 import { AdEventListener } from '../types/AdEventListener';
 import { AdEventsListener } from '../types/AdEventsListener';
-import { AdShowOptions } from '../types/AdShowOptions';
 import { RequestOptions } from '../types/RequestOptions';
-import { MobileAdInterface } from '../types/MobileAd.interface';
-
-let _rewardedRequest = 0;
 
 /**
  * A class for interacting and showing Rewarded Ads.
@@ -75,7 +70,8 @@ let _rewardedRequest = 0;
  * The rewarded advert will be presented to the user, and several more events can be triggered such as the user clicking the
  * advert, closing it or completing the action.
  */
-export class RewardedAd extends MobileAd implements MobileAdInterface {
+export class RewardedAd extends MobileAd {
+  protected static _rewardedRequest = 0;
   /**
    * Creates a new RewardedAd instance.
    *
@@ -101,7 +97,7 @@ export class RewardedAd extends MobileAd implements MobileAdInterface {
    * @param adUnitId The Ad Unit ID for the Rewarded Ad. You can find this on your Google Mobile Ads dashboard.
    * @param requestOptions Optional RequestOptions used to load the ad.
    */
-  static createForAdRequest(adUnitId: string, requestOptions?: RequestOptions): RewardedAd {
+  static createForAdRequest(adUnitId: string, requestOptions?: RequestOptions) {
     if (!isString(adUnitId)) {
       throw new Error("RewardedAd.createForAdRequest(*) 'adUnitId' expected an string value.");
     }
@@ -115,40 +111,8 @@ export class RewardedAd extends MobileAd implements MobileAdInterface {
       }
     }
 
-    const requestId = _rewardedRequest++;
+    const requestId = RewardedAd._rewardedRequest++;
     return new RewardedAd('rewarded', MobileAds(), requestId, adUnitId, options);
-  }
-
-  load() {
-    // Prevent multiple load calls
-    if (this._loaded || this._isLoadCalled) {
-      return;
-    }
-
-    this._isLoadCalled = true;
-    this._googleMobileAds.native.rewardedLoad(
-      this._requestId,
-      this._adUnitId,
-      this._requestOptions,
-    );
-  }
-
-  show(showOptions?: AdShowOptions) {
-    if (!this._loaded) {
-      throw new Error(
-        'RewardedAd.show() The requested RewardedAd has not loaded and could not be shown.',
-      );
-    }
-
-    let options;
-    try {
-      options = validateAdShowOptions(showOptions);
-    } catch (e) {
-      if (e instanceof Error) {
-        throw new Error(`RewardedAd.show(*) ${e.message}.`);
-      }
-    }
-    return this._googleMobileAds.native.rewardedShow(this._requestId, this._adUnitId, options);
   }
 
   addAdEventsListener<T extends AdEventType | RewardedAdEventType>(

--- a/src/types/GoogleMobileAdsNativeModule.ts
+++ b/src/types/GoogleMobileAdsNativeModule.ts
@@ -8,9 +8,9 @@ export interface GoogleMobileAdsNativeModule {
   setRequestConfiguration(requestConfiguration?: RequestConfiguration): Promise<void>;
   openAdInspector(): () => Promise<void>;
   appOpenLoad(requestId: number, adUnitId: string, requestOptions: RequestOptions): void;
-  appOpenShow(requestId: number, showOptions?: AdShowOptions): Promise<void>;
+  appOpenShow(requestId: number, adUnitId: string, showOptions?: AdShowOptions): Promise<void>;
   interstitialLoad(requestId: number, adUnitId: string, requestOptions: RequestOptions): void;
-  interstitialShow(requestId: number, showOptions?: AdShowOptions): Promise<void>;
+  interstitialShow(requestId: number, adUnitId: string, showOptions?: AdShowOptions): Promise<void>;
   rewardedLoad(requestId: number, adUnitId: string, requestOptions: RequestOptions): void;
   rewardedShow(requestId: number, adUnitId: string, showOptions?: AdShowOptions): Promise<void>;
 }


### PR DESCRIPTION
### Description

Moved common `load` and `show` methods in each full screen ad classes into `MobileAd` class.

### Related issues

### Release Summary

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
