### PR TITLE
refactor: export types to index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,4 @@ export { BannerAd } from './ads/BannerAd';
 export { useAppOpenAd } from './hooks/useAppOpenAd';
 export { useInterstitialAd } from './hooks/useInterstitialAd';
 export { useRewardedAd } from './hooks/useRewardedAd';
+export * from './types';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export * from './AdapterStatus';
+export * from './AdEventListener';
+export * from './AdEventsListener';
+export * from './AdsConsent.interface';
+export * from './AdShowOptions';
+export * from './AdStates';
+export * from './BannerAdProps';
+export * from './RequestConfiguration';
+export * from './RequestOptions';
+export * from './RewardedAdReward';


### PR DESCRIPTION
### Description

Added internal types to export list in index.ts.
Library users will be able to use library more flexibly with the exported types.

### Related issues

### Release Summary

export types

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
