### PR TITLE
fix(types): openAdInspector returns Promise, not function

### DIFF
--- a/src/types/GoogleMobileAdsNativeModule.ts
+++ b/src/types/GoogleMobileAdsNativeModule.ts
@@ -6,7 +6,7 @@ import { AdShowOptions } from './AdShowOptions';
 export interface GoogleMobileAdsNativeModule {
   initialize(): Promise<AdapterStatus[]>;
   setRequestConfiguration(requestConfiguration?: RequestConfiguration): Promise<void>;
-  openAdInspector(): () => Promise<void>;
+  openAdInspector(): Promise<void>;
   appOpenLoad(requestId: number, adUnitId: string, requestOptions: RequestOptions): void;
   appOpenShow(requestId: number, adUnitId: string, showOptions?: AdShowOptions): Promise<void>;
   interstitialLoad(requestId: number, adUnitId: string, requestOptions: RequestOptions): void;

--- a/src/types/MobileAdsModule.interface.ts
+++ b/src/types/MobileAdsModule.interface.ts
@@ -39,7 +39,7 @@ export interface MobileAdsModuleInterface {
    *
    * @see https://developers.google.com/ad-manager/mobile-ads-sdk/android/ad-inspector
    */
-  openAdInspector(): () => Promise<void>;
+  openAdInspector(): Promise<void>;
 
   /**
    * The native module instance for the Google Mobile Ads service.


### PR DESCRIPTION
### Description

Fixes wrong return type of `openAdInspector` method in `MobileAds` class.

### Related issues

### Release Summary

fix wrong openAdInspector method return type

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
