### PR TITLE
feat: add destroy method

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.java
@@ -156,4 +156,9 @@ public class ReactNativeGoogleMobileAdsAppOpenModule extends ReactNativeModule {
               }
             });
   }
+
+  @ReactMethod
+  public void appOpenDestroy(int requestId) {
+    appOpenAd = null;
+  }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.java
@@ -48,7 +48,7 @@ import javax.annotation.Nullable;
 
 public class ReactNativeGoogleMobileAdsInterstitialModule extends ReactNativeModule {
   private static final String SERVICE = "RNGoogleMobileAdsInterstitialModule";
-  private static SparseArray<InterstitialAd> interstitialAdArray = new SparseArray<>();
+  private static final SparseArray<InterstitialAd> interstitialAdArray = new SparseArray<>();
 
   public ReactNativeGoogleMobileAdsInterstitialModule(ReactApplicationContext reactContext) {
     super(reactContext, SERVICE);
@@ -83,7 +83,7 @@ public class ReactNativeGoogleMobileAdsInterstitialModule extends ReactNativeMod
                         public void onAdDismissedFullScreenContent() {
                           sendInterstitialEvent(
                               GOOGLE_MOBILE_ADS_EVENT_CLOSED, requestId, adUnitId, null);
-                          interstitialAdArray.put(requestId, null);
+                          interstitialAdArray.remove(requestId);
                         }
 
                         @Override
@@ -174,5 +174,10 @@ public class ReactNativeGoogleMobileAdsInterstitialModule extends ReactNativeMod
               interstitialAd.show(getCurrentActivity());
               promise.resolve(null);
             });
+  }
+
+  @ReactMethod
+  public void interstitialDestroy(int requestId) {
+    interstitialAdArray.remove(requestId);
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModule.java
@@ -47,7 +47,7 @@ import io.invertase.googlemobileads.common.ReactNativeModule;
 
 public class ReactNativeGoogleMobileAdsRewardedInterstitialModule extends ReactNativeModule {
   private static final String SERVICE = "RNGoogleMobileAdsRewardedInterstitialModule";
-  private static SparseArray<RewardedInterstitialAd> rewardedInterstitialAdArray =
+  private static final SparseArray<RewardedInterstitialAd> rewardedInterstitialAdArray =
       new SparseArray<>();
 
   public ReactNativeGoogleMobileAdsRewardedInterstitialModule(
@@ -138,6 +138,7 @@ public class ReactNativeGoogleMobileAdsRewardedInterstitialModule extends ReactN
                         public void onAdDismissedFullScreenContent() {
                           sendRewardedInterstitialEvent(
                               GOOGLE_MOBILE_ADS_EVENT_CLOSED, requestId, adUnitId, null, null);
+                          rewardedInterstitialAdArray.remove(requestId);
                         }
                       };
 
@@ -195,5 +196,10 @@ public class ReactNativeGoogleMobileAdsRewardedInterstitialModule extends ReactN
               rewardedInterstitialAd.show(getCurrentActivity(), onUserEarnedRewardListener);
               promise.resolve(null);
             });
+  }
+
+  @ReactMethod
+  public void rewardedInterstitialDestroy(int requestId) {
+    rewardedInterstitialAdArray.remove(requestId);
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModule.java
@@ -30,7 +30,7 @@ import io.invertase.googlemobileads.common.ReactNativeModule;
 
 public class ReactNativeGoogleMobileAdsRewardedModule extends ReactNativeModule {
   private static final String SERVICE = "RNGoogleMobileAdsRewardedModule";
-  private static SparseArray<RewardedAd> rewardedAdArray = new SparseArray<>();
+  private static final SparseArray<RewardedAd> rewardedAdArray = new SparseArray<>();
 
   public ReactNativeGoogleMobileAdsRewardedModule(ReactApplicationContext reactContext) {
     super(reactContext, SERVICE);
@@ -116,6 +116,7 @@ public class ReactNativeGoogleMobileAdsRewardedModule extends ReactNativeModule 
                         public void onAdDismissedFullScreenContent() {
                           sendRewardedEvent(
                               GOOGLE_MOBILE_ADS_EVENT_CLOSED, requestId, adUnitId, null, null);
+                          rewardedAdArray.remove(requestId);
                         }
                       };
 
@@ -172,5 +173,10 @@ public class ReactNativeGoogleMobileAdsRewardedModule extends ReactNativeModule 
               rewardedAd.show(getCurrentActivity(), onUserEarnedRewardListener);
               promise.resolve(null);
             });
+  }
+
+  @ReactMethod
+  public void rewardedDestroy(int requestId) {
+    rewardedAdArray.remove(requestId);
   }
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.h
@@ -23,7 +23,6 @@
 
 @interface RNGoogleMobileAdsAppOpenModule : NSObject <RCTBridgeModule>
 
-@property(strong, nonatomic) GADAppOpenAd* appOpenAd;
-@property(strong, nonatomic) RNGoogleMobileAdsFullScreenContentDelegate* appOpenDelegate;
++ (void)removeAppOpen;
 
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsFullScreenContentDelegate.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsFullScreenContentDelegate.m
@@ -16,6 +16,10 @@
  */
 
 #import "RNGoogleMobileAdsFullScreenContentDelegate.h"
+#import "RNGoogleMobileAdsAppOpenModule.h"
+#import "RNGoogleMobileAdsInterstitialModule.h"
+#import "RNGoogleMobileAdsRewardedInterstitialModule.h"
+#import "RNGoogleMobileAdsRewardedModule.h"
 
 @implementation RNGoogleMobileAdsFullScreenContentDelegate
 
@@ -52,6 +56,15 @@
                               adUnitId:_adUnitId
                                  error:nil
                                   data:nil];
+  if ([_sendAdEvent isEqualToString:GOOGLE_MOBILE_ADS_EVENT_APP_OPEN]) {
+    [RNGoogleMobileAdsAppOpenModule removeAppOpen];
+  } else if ([_sendAdEvent isEqualToString:GOOGLE_MOBILE_ADS_EVENT_INTERSTITIAL]) {
+    [RNGoogleMobileAdsInterstitialModule removeInterstitial:_requestId];
+  } else if ([_sendAdEvent isEqualToString:GOOGLE_MOBILE_ADS_EVENT_REWARDED]) {
+    [RNGoogleMobileAdsRewardedModule removeRewarded:_requestId];
+  } else if ([_sendAdEvent isEqualToString:GOOGLE_MOBILE_ADS_EVENT_REWARDED_INTERSTITIAL]) {
+    [RNGoogleMobileAdsRewardedInterstitialModule removeRewardedInterstitial:_requestId];
+  }
 }
 
 /// Called when the ad receives an app event.

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.h
@@ -22,4 +22,6 @@
 
 @interface RNGoogleMobileAdsInterstitialModule : NSObject <RCTBridgeModule>
 
++ (void)removeInterstitial:(nonnull NSNumber *)requestId;
+
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.m
@@ -56,8 +56,7 @@ RCT_EXPORT_MODULE();
 
 - (void)invalidate {
   for (NSNumber *id in [interstitialMap allKeys]) {
-    [interstitialMap removeObjectForKey:id];
-    [interstitialDelegateMap removeObjectForKey:id];
+    [RNGoogleMobileAdsInterstitialModule removeInterstitial:id];
   }
 }
 
@@ -132,6 +131,17 @@ RCT_EXPORT_METHOD(interstitialShow
                            @"message" : @"Interstitial ad attempted to show but was not ready.",
                          } mutableCopy]];
   }
+}
+
+RCT_EXPORT_METHOD(interstitialDestroy : (nonnull NSNumber *)requestId) {
+  [RNGoogleMobileAdsInterstitialModule removeInterstitial:requestId];
+}
+
+#pragma mark -
+
++ (void)removeInterstitial:(nonnull NSNumber *)requestId {
+  [interstitialMap removeObjectForKey:requestId];
+  [interstitialDelegateMap removeObjectForKey:requestId];
 }
 
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedInterstitialModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedInterstitialModule.h
@@ -22,4 +22,6 @@
 
 @interface RNGoogleMobileAdsRewardedInterstitialModule : NSObject <RCTBridgeModule>
 
++ (void)removeRewardedInterstitial:(nonnull NSNumber *)requestId;
+
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedInterstitialModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedInterstitialModule.m
@@ -56,8 +56,7 @@ RCT_EXPORT_MODULE();
 
 - (void)invalidate {
   for (NSNumber *id in [rewardedInterstitialMap allKeys]) {
-    [rewardedInterstitialMap removeObjectForKey:id];
-    [rewardedInterstitialDelegateMap removeObjectForKey:id];
+    [RNGoogleMobileAdsRewardedInterstitialModule removeRewardedInterstitial:id];
   }
 }
 
@@ -168,6 +167,17 @@ RCT_EXPORT_METHOD(rewardedInterstitialShow
                                @"Rewarded Interstitial ad attempted to show but was not ready.",
                          } mutableCopy]];
   }
+}
+
+RCT_EXPORT_METHOD(rewardedInterstitialDestroy : (nonnull NSNumber *)requestId) {
+  [RNGoogleMobileAdsRewardedInterstitialModule removeRewardedInterstitial:requestId];
+}
+
+#pragma mark -
+
++ (void)removeRewardedInterstitial:(nonnull NSNumber *)requestId {
+  [rewardedInterstitialMap removeObjectForKey:requestId];
+  [rewardedInterstitialDelegateMap removeObjectForKey:requestId];
 }
 
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.h
@@ -22,4 +22,6 @@
 
 @interface RNGoogleMobileAdsRewardedModule : NSObject <RCTBridgeModule>
 
++ (void)removeRewarded:(nonnull NSNumber *)requestId;
+
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.m
@@ -56,8 +56,7 @@ RCT_EXPORT_MODULE();
 
 - (void)invalidate {
   for (NSNumber *id in [rewardedMap allKeys]) {
-    [rewardedMap removeObjectForKey:id];
-    [rewardedDelegateMap removeObjectForKey:id];
+    [RNGoogleMobileAdsRewardedModule removeRewarded:id];
   }
 }
 
@@ -167,6 +166,17 @@ RCT_EXPORT_METHOD(rewardedShow
                            @"message" : @"Rewarded ad attempted to show but was not ready.",
                          } mutableCopy]];
   }
+}
+
+RCT_EXPORT_METHOD(rewardedDestroy : (nonnull NSNumber *)requestId) {
+  [RNGoogleMobileAdsRewardedModule removeRewarded:requestId];
+}
+
+#pragma mark -
+
++ (void)removeRewarded:(nonnull NSNumber *)requestId {
+  [rewardedMap removeObjectForKey:requestId];
+  [rewardedDelegateMap removeObjectForKey:requestId];
 }
 
 @end

--- a/src/hooks/useAppOpenAd.ts
+++ b/src/hooks/useAppOpenAd.ts
@@ -37,7 +37,8 @@ export function useAppOpenAd(
   const [appOpenAd, setAppOpenAd] = useState<AppOpenAd | null>(null);
 
   useDeepCompareEffect(() => {
-    setAppOpenAd(() => {
+    setAppOpenAd(prevAd => {
+      prevAd?.destroy();
       return adUnitId ? AppOpenAd.createForAdRequest(adUnitId, requestOptions) : null;
     });
   }, [adUnitId, requestOptions]);

--- a/src/hooks/useInterstitialAd.ts
+++ b/src/hooks/useInterstitialAd.ts
@@ -37,7 +37,8 @@ export function useInterstitialAd(
   const [interstitialAd, setInterstitialAd] = useState<InterstitialAd | null>(null);
 
   useDeepCompareEffect(() => {
-    setInterstitialAd(() => {
+    setInterstitialAd(prevAd => {
+      prevAd?.destroy();
       return adUnitId ? InterstitialAd.createForAdRequest(adUnitId, requestOptions) : null;
     });
   }, [adUnitId, requestOptions]);

--- a/src/hooks/useRewardedAd.ts
+++ b/src/hooks/useRewardedAd.ts
@@ -37,7 +37,8 @@ export function useRewardedAd(
   const [rewardedAd, setRewardedAd] = useState<RewardedAd | null>(null);
 
   useDeepCompareEffect(() => {
-    setRewardedAd(() => {
+    setRewardedAd(prevAd => {
+      prevAd?.destroy();
       return adUnitId ? RewardedAd.createForAdRequest(adUnitId, requestOptions) : null;
     });
   }, [adUnitId, requestOptions]);

--- a/src/hooks/useRewardedInterstitialAd.ts
+++ b/src/hooks/useRewardedInterstitialAd.ts
@@ -38,7 +38,8 @@ export function useRewardedInterstitialAd(
     useState<RewardedInterstitialAd | null>(null);
 
   useDeepCompareEffect(() => {
-    setRewardedInterstitialAd(() => {
+    setRewardedInterstitialAd(prevAd => {
+      prevAd?.destroy();
       return adUnitId ? RewardedInterstitialAd.createForAdRequest(adUnitId, requestOptions) : null;
     });
   }, [adUnitId, requestOptions]);

--- a/src/types/GoogleMobileAdsNativeModule.ts
+++ b/src/types/GoogleMobileAdsNativeModule.ts
@@ -9,6 +9,7 @@ type AdShowFunction = (
   adUnitId: string,
   showOptions?: AdShowOptions,
 ) => Promise<void>;
+type AdDestroyFunction = (requestId: number) => void;
 
 export interface GoogleMobileAdsNativeModule {
   initialize(): Promise<AdapterStatus[]>;
@@ -16,10 +17,14 @@ export interface GoogleMobileAdsNativeModule {
   openAdInspector(): Promise<void>;
   appOpenLoad: AdLoadFunction;
   appOpenShow: AdShowFunction;
+  appOpenDestroy: AdDestroyFunction;
   interstitialLoad: AdLoadFunction;
   interstitialShow: AdShowFunction;
+  interstitialDestroy: AdDestroyFunction;
   rewardedLoad: AdLoadFunction;
   rewardedShow: AdShowFunction;
+  rewardedDestroy: AdDestroyFunction;
   rewardedInterstitialLoad: AdLoadFunction;
   rewardedInterstitialShow: AdShowFunction;
+  rewardedInterstitialDestroy: AdDestroyFunction;
 }

--- a/src/types/MobileAd.interface.ts
+++ b/src/types/MobileAd.interface.ts
@@ -110,4 +110,11 @@ export interface MobileAdInterface {
    * Remove all registered event listeners.
    */
   removeAllListeners(): void;
+
+  /**
+   * Destroy the advert. All event listeners will be removed and the advert will be unloaded.
+   *
+   * **After destroying the advert, the methods of this interface should not be called.**
+   */
+  destroy(): void;
 }


### PR DESCRIPTION
### Description

Adds `destroy` method for memory cleanup. Developers can call the method in appropriate timing.
Also, ad instance in native side code will be automatically removed from reference array after the ad is dismissed.
This changes may reduce some memory leaks.

### Related issues

### Release Summary

Adds `destroy` method for full screen ads.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
