### PR TITLE
fix(android, fluid): Initial attempt at supporting fluid ads

### DIFF
--- a/RNGoogleMobileAdsExample/App.tsx
+++ b/RNGoogleMobileAdsExample/App.tsx
@@ -180,6 +180,41 @@ class BannerTest implements Test {
   }
 }
 
+class FluidTest implements Test {
+  getPath(): string {
+    return 'Fluid';
+  }
+
+  getTestType(): TestType {
+    return TestType.Interactive;
+  }
+
+  render(onMount: (component: any) => void): React.ReactNode {
+    return (
+      <View ref={onMount}>
+        <BannerAd
+          unitId={TestIds.FLUID}
+          size={BannerAdSize.FLUID}
+          requestOptions={{
+            requestNonPersonalizedAdsOnly: true,
+          }}
+        />
+      </View>
+    );
+  }
+
+  execute(component: any, complete: (result: TestResult) => void): void {
+    let results = new TestResult();
+    try {
+      // You can do anything here, it will execute on-device + in-app. Results are aggregated + visible in-app.
+    } catch (error) {
+      results.errors.push('Received unexpected error...');
+    } finally {
+      complete(results);
+    }
+  }
+}
+
 const rewarded = RewardedAd.createForAdRequest(TestIds.REWARDED, {
   requestNonPersonalizedAdsOnly: true,
   keywords: ['fashion', 'clothing'],
@@ -778,6 +813,7 @@ class GAMInterstitialTest implements Test {
 
 // All tests must be registered - a future feature will allow auto-bundling of tests via configured path or regex
 TestRegistry.registerTest(new BannerTest());
+TestRegistry.registerTest(new FluidTest());
 TestRegistry.registerTest(new AppOpenTest());
 TestRegistry.registerTest(new InterstitialTest());
 TestRegistry.registerTest(new RewardedTest());

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -153,8 +153,12 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
               // TODO size=FLUID is still not working
               left = 0;
               top = 0;
-              width = reactViewGroup.getWidth();
-              height = reactViewGroup.getHeight();
+              width = Math.max(
+                reactViewGroup.getWidth(),
+                adSize.getWidthInPixels(reactViewGroup.getContext()));
+              height = Math.max(
+                reactViewGroup.getHeight(),
+                adSize.getHeightInPixels(reactViewGroup.getContext()));
             } else {
               left = adView.getLeft();
               top = adView.getTop();
@@ -230,6 +234,9 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
         ((AdManagerAdView) adView).setManualImpressionsEnabled(true);
       }
     } else {
+      if (sizes.contains(AdSize.FLUID) && sizes.size() == 1) {
+        isFluid = true;
+      }
       adView.setAdSize(sizes.get(0));
     }
 

--- a/src/TestIds.ts
+++ b/src/TestIds.ts
@@ -20,6 +20,7 @@ import { Platform } from 'react-native';
 export const TestIds = {
   APP_OPEN: '',
   BANNER: '',
+  FLUID: '',
   INTERSTITIAL: '',
   REWARDED: '',
   REWARDED_INTERSTITIAL: '',
@@ -33,6 +34,7 @@ export const TestIds = {
     android: {
       APP_OPEN: 'ca-app-pub-3940256099942544/3419835294',
       BANNER: 'ca-app-pub-3940256099942544/6300978111',
+      FLUID: 'ca-app-pub-3940256099942544/6300978111',
       INTERSTITIAL: 'ca-app-pub-3940256099942544/1033173712',
       REWARDED: 'ca-app-pub-3940256099942544/5224354917',
       REWARDED_INTERSTITIAL: 'ca-app-pub-3940256099942544/5354046379',
@@ -40,6 +42,7 @@ export const TestIds = {
     ios: {
       APP_OPEN: 'ca-app-pub-3940256099942544/5662855259',
       BANNER: 'ca-app-pub-3940256099942544/2934735716',
+      FLUID: 'ca-app-pub-3940256099942544/2934735716',
       INTERSTITIAL: 'ca-app-pub-3940256099942544/4411468910',
       REWARDED: 'ca-app-pub-3940256099942544/1712485313',
       REWARDED_INTERSTITIAL: 'ca-app-pub-3940256099942544/6978759866',

--- a/type-test.ts
+++ b/type-test.ts
@@ -51,6 +51,7 @@ console.log(googleMobileAds.BannerAdSize.FLUID);
 console.log(googleMobileAds.BannerAdSize.FULL_BANNER);
 
 console.log(googleMobileAds.TestIds.BANNER);
+console.log(googleMobileAds.TestIds.FLUID);
 console.log(googleMobileAds.TestIds.INTERSTITIAL);
 console.log(googleMobileAds.TestIds.REWARDED);
 console.log(googleMobileAds.TestIds.BANNER);


### PR DESCRIPTION
### Description

Fluid ads are not currently working in our React Native project, and it also appears are not supported in this module. I'm hoping that fixing it here will help us understand how to fix it in our project as well. This is an initial version, it's not even yet clear to me if it works, why it used to fail, etc. But I figured I'd start with a PR to get the ridicule out of the way early.

### Related issues

Fixes #120 

### Release Summary

Fluid ads report zero height in some cases, we now attempt to reconstruct the size properly.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS` (only in that it is not relevant)
- My change includes tests;
  - [X] `e2e` tests added or updated in `__tests__e2e__`
  - [X] `jest` tests added or updated in `__tests__`
- This is a breaking change;
  - [X] No

### Test Plan

A test has been added, but I'm not yet convinced it's passing because I don't have control over the placements in the tests.

:fire: