### PR TITLE
fix: allow undefined/null configuration properties

### DIFF
--- a/e2e/admob.e2e.js
+++ b/e2e/admob.e2e.js
@@ -49,6 +49,11 @@ describe('googleAds', function () {
           maxAdContentRating: googleAds.MaxAdContentRating.G,
         });
       });
+
+      it('accepts undefined or null', async function () {
+        await googleAds.setRequestConfiguration({ maxAdContentRating: undefined });
+        await googleAds.setRequestConfiguration({ maxAdContentRating: null });
+      });
     });
 
     describe('tagForChildDirectedTreatment', function () {
@@ -71,6 +76,11 @@ describe('googleAds', function () {
           tagForChildDirectedTreatment: false,
         });
       });
+
+      it('accepts undefined or null', async function () {
+        await googleAds.setRequestConfiguration({ tagForChildDirectedTreatment: undefined });
+        await googleAds.setRequestConfiguration({ tagForChildDirectedTreatment: null });
+      });
     });
 
     describe('tagForUnderAgeOfConsent', function () {
@@ -92,6 +102,11 @@ describe('googleAds', function () {
         await googleAds.setRequestConfiguration({
           tagForUnderAgeOfConsent: false,
         });
+      });
+
+      it('accepts undefined or null', async function () {
+        await googleAds.setRequestConfiguration({ tagForUnderAgeOfConsent: undefined });
+        await googleAds.setRequestConfiguration({ tagForUnderAgeOfConsent: null });
       });
     });
   });

--- a/e2e/consent.e2e.js
+++ b/e2e/consent.e2e.js
@@ -39,6 +39,22 @@ describe('googleAds AdsConsent', function () {
       }
     });
 
+    it('accepts undefined or null properties', function () {
+      AdsConsent.requestInfoUpdate({
+        debugGeography: undefined,
+        tagForUnderAgeOfConsent: undefined,
+        testDeviceIdentifiers: undefined,
+      });
+
+      AdsConsent.requestInfoUpdate({
+        debugGeography: undefined,
+        tagForUnderAgeOfConsent: undefined,
+        testDeviceIdentifiers: undefined,
+      });
+
+      return Promise.resolve();
+    });
+
     it('throws if debugGeography is not a AdsConsentDebugGeography value', function () {
       try {
         AdsConsent.requestInfoUpdate({

--- a/e2e/requestOptions.e2e.js
+++ b/e2e/requestOptions.e2e.js
@@ -37,6 +37,58 @@ describe('googleAds requestOptions', function () {
     }
   });
 
+  it('accepts undefined properties', function () {
+    const v = validator({
+      requestNonPersonalizedAdsOnly: undefined,
+      networkExtras: undefined,
+      keywords: undefined,
+      testDevices: undefined,
+      contentUrl: undefined,
+      location: undefined,
+      locationAccuracy: undefined,
+      requestAgent: undefined,
+      serverSideVerificationOptions: undefined,
+    });
+
+    v.requestNonPersonalizedAdsOnly.should.eql(undefined);
+    v.networkExtras.should.eql(undefined);
+    v.keywords.should.eql(undefined);
+    v.testDevices.should.eql(undefined);
+    v.contentUrl.should.eql(undefined);
+    v.location.should.eql(undefined);
+    v.locationAccuracy.should.eql(undefined);
+    v.requestAgent.should.eql(undefined);
+    v.serverSideVerificationOptions.should.eql(undefined);
+
+    return Promise.resolve();
+  });
+
+  it('accepts bull properties', function () {
+    const v = validator({
+      requestNonPersonalizedAdsOnly: null,
+      networkExtras: null,
+      keywords: null,
+      testDevices: null,
+      contentUrl: null,
+      location: null,
+      locationAccuracy: null,
+      requestAgent: null,
+      serverSideVerificationOptions: null,
+    });
+
+    v.requestNonPersonalizedAdsOnly.should.eql(null);
+    v.networkExtras.should.eql(null);
+    v.keywords.should.eql(null);
+    v.testDevices.should.eql(null);
+    v.contentUrl.should.eql(null);
+    v.location.should.eql(null);
+    v.locationAccuracy.should.eql(null);
+    v.requestAgent.should.eql(null);
+    v.serverSideVerificationOptions.should.eql(null);
+
+    return Promise.resolve();
+  });
+
   describe('requestNonPersonalizedAdsOnly', function () {
     it('throws if requestNonPersonalizedAdsOnly is not a boolean', function () {
       try {

--- a/e2e/showOptions.e2e.js
+++ b/e2e/showOptions.e2e.js
@@ -37,6 +37,22 @@ describe('googleAds showOptions', function () {
     }
   });
 
+  it('accepts undefined properties', function () {
+    const v = validator({
+      immersiveModeEnabled: undefined,
+    });
+
+    v.should.eql(jet.contextify({}));
+  });
+
+  it('accepts null properties', function () {
+    const v = validator({
+      immersiveModeEnabled: undefined,
+    });
+
+    v.should.eql(jet.contextify({}));
+  });
+
   it('throws if immersiveModeEnabled is not a boolean', function () {
     try {
       validator({

--- a/src/AdsConsent.ts
+++ b/src/AdsConsent.ts
@@ -20,7 +20,7 @@ import { NativeModules } from 'react-native';
 import { AdsConsentDebugGeography } from './AdsConsentDebugGeography';
 import { AdsConsentPurposes } from './AdsConsentPurposes';
 import { AdsConsentSpecialFeatures } from './AdsConsentSpecialFeatures';
-import { hasOwnProperty, isArray, isBoolean, isObject, isString } from './common';
+import { isPropertySet, isArray, isBoolean, isObject, isString } from './common';
 import {
   AdsConsentFormResult,
   AdsConsentInfo,
@@ -38,7 +38,7 @@ export const AdsConsent: AdsConsentInterface = {
     }
 
     if (
-      hasOwnProperty(options, 'debugGeography') &&
+      isPropertySet(options, 'debugGeography') &&
       options.debugGeography !== AdsConsentDebugGeography.DISABLED &&
       options.debugGeography !== AdsConsentDebugGeography.EEA &&
       options.debugGeography !== AdsConsentDebugGeography.NOT_EEA
@@ -49,7 +49,7 @@ export const AdsConsent: AdsConsentInterface = {
     }
 
     if (
-      hasOwnProperty(options, 'tagForUnderAgeOfConsent') &&
+      isPropertySet(options, 'tagForUnderAgeOfConsent') &&
       !isBoolean(options.tagForUnderAgeOfConsent)
     ) {
       throw new Error(
@@ -57,7 +57,7 @@ export const AdsConsent: AdsConsentInterface = {
       );
     }
 
-    if (hasOwnProperty(options, 'testDeviceIdentifiers')) {
+    if (isPropertySet(options, 'testDeviceIdentifiers')) {
       if (!isArray(options.testDeviceIdentifiers)) {
         throw new Error(
           "AdsConsent.requestInfoUpdate(*) 'options.testDeviceIdentifiers' expected an array of string values.",

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -17,7 +17,7 @@
 
 import { Platform } from 'react-native';
 import * as Base64 from './Base64';
-import { isString } from './validate';
+import { isString, isNull, isUndefined } from './validate';
 
 export * from './id';
 export * from './path';
@@ -67,6 +67,12 @@ export function isError(value: unknown) {
 
 export function hasOwnProperty(target: unknown, property: PropertyKey) {
   return Object.hasOwnProperty.call(target, property);
+}
+
+export function isPropertySet(target: any, property: PropertyKey) {
+  return (
+    hasOwnProperty(target, property) && !isUndefined(target[property]) && !isNull(target[property])
+  );
 }
 
 /**

--- a/src/validateAdRequestConfiguration.ts
+++ b/src/validateAdRequestConfiguration.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { hasOwnProperty, isArray, isBoolean, isObject } from './common';
+import { isPropertySet, isArray, isBoolean, isObject } from './common';
 import { MaxAdContentRating } from './MaxAdContentRating';
 import { RequestConfiguration } from './types/RequestConfiguration';
 
@@ -41,7 +41,7 @@ export function validateAdRequestConfiguration(requestConfiguration: RequestConf
     out.maxAdContentRating = requestConfiguration.maxAdContentRating;
   }
 
-  if (hasOwnProperty(requestConfiguration, 'tagForChildDirectedTreatment')) {
+  if (isPropertySet(requestConfiguration, 'tagForChildDirectedTreatment')) {
     if (!isBoolean(requestConfiguration.tagForChildDirectedTreatment)) {
       throw new Error(
         "'requestConfiguration.tagForChildDirectedTreatment' expected a boolean value",
@@ -51,7 +51,7 @@ export function validateAdRequestConfiguration(requestConfiguration: RequestConf
     out.tagForChildDirectedTreatment = requestConfiguration.tagForChildDirectedTreatment;
   }
 
-  if (hasOwnProperty(requestConfiguration, 'tagForUnderAgeOfConsent')) {
+  if (isPropertySet(requestConfiguration, 'tagForUnderAgeOfConsent')) {
     if (!isBoolean(requestConfiguration.tagForUnderAgeOfConsent)) {
       throw new Error("'requestConfiguration.tagForUnderAgeOfConsent' expected a boolean value");
     }
@@ -59,7 +59,7 @@ export function validateAdRequestConfiguration(requestConfiguration: RequestConf
     out.tagForUnderAgeOfConsent = requestConfiguration.tagForUnderAgeOfConsent;
   }
 
-  if (hasOwnProperty(requestConfiguration, 'testDeviceIdentifiers')) {
+  if (isPropertySet(requestConfiguration, 'testDeviceIdentifiers')) {
     if (!isArray(requestConfiguration.testDeviceIdentifiers)) {
       throw new Error("'requestConfiguration.testDeviceIdentifiers' expected an array value");
     }

--- a/src/validateAdRequestOptions.ts
+++ b/src/validateAdRequestOptions.ts
@@ -16,7 +16,7 @@
  */
 
 import {
-  hasOwnProperty,
+  isPropertySet,
   isArray,
   isBoolean,
   isObject,
@@ -37,7 +37,7 @@ export function validateAdRequestOptions(options?: RequestOptions) {
     throw new Error("'options' expected an object value");
   }
 
-  if (hasOwnProperty(options, 'requestNonPersonalizedAdsOnly')) {
+  if (isPropertySet(options, 'requestNonPersonalizedAdsOnly')) {
     if (!isBoolean(options.requestNonPersonalizedAdsOnly)) {
       throw new Error("'options.requestNonPersonalizedAdsOnly' expected a boolean value");
     }

--- a/src/validateAdShowOptions.ts
+++ b/src/validateAdShowOptions.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { hasOwnProperty, isBoolean, isObject, isUndefined } from './common';
+import { isPropertySet, isBoolean, isObject, isUndefined } from './common';
 import { AdShowOptions } from './types/AdShowOptions';
 
 export function validateAdShowOptions(options?: AdShowOptions) {
@@ -29,7 +29,7 @@ export function validateAdShowOptions(options?: AdShowOptions) {
     throw new Error("'options' expected an object value");
   }
 
-  if (hasOwnProperty(options, 'immersiveModeEnabled')) {
+  if (isPropertySet(options, 'immersiveModeEnabled')) {
     if (!isBoolean(options.immersiveModeEnabled)) {
       throw new Error("'options.immersiveModeEnabled' expected a boolean value");
     }


### PR DESCRIPTION
### Description

In [`RequestConfiguration` interface](https://github.com/invertase/react-native-google-mobile-ads/blob/469b3be4197545c0c6f1da248539d94b864d9be9/src/types/RequestConfiguration.ts) every property is optional, so in theory the following piece of code is considered correct:

```tsx
await mobileAds().setRequestConfiguration({
  testDeviceIdentifiers: undefined,
});
```

In practice, it will throw an error on the production release:

```
googleMobileAds.setRequestConfiguration(*) 'requestConfiguration.testDeviceIdentifiers' expected an array value
```

This is because this library performs [`hasOwnProperty` check](https://github.com/invertase/react-native-google-mobile-ads/blob/469b3be4197545c0c6f1da248539d94b864d9be9/src/validateAdRequestConfiguration.ts#L62=) which returns `true` if a given property exists event if its value is `undefined`.

I created a `isPropertySet` to check not only if the property is set, but also if it's not `null` or `undefined`. With this change the example code above will not throw, because `testDeviceIdentifiers` will get ignored.

### Related issues

Fixes https://github.com/invertase/react-native-google-mobile-ads/issues/137

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No
  
  🔥