### PR TITLE
fix: batch banner ad prop update

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -58,6 +58,7 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
   private List<AdSize> sizes;
   private String unitId;
   private Boolean manualImpressionsEnabled;
+  private boolean propsChanged;
   private boolean isFluid;
 
   @Nonnull
@@ -102,13 +103,13 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
   @ReactProp(name = "unitId")
   public void setUnitId(ReactViewGroup reactViewGroup, String value) {
     unitId = value;
-    requestAd(reactViewGroup);
+    propsChanged = true;
   }
 
   @ReactProp(name = "request")
   public void setRequest(ReactViewGroup reactViewGroup, ReadableMap value) {
     request = ReactNativeGoogleMobileAdsCommon.buildAdRequest(value);
-    requestAd(reactViewGroup);
+    propsChanged = true;
   }
 
   @ReactProp(name = "sizes")
@@ -121,13 +122,22 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
       }
     }
     sizes = sizeList;
-    requestAd(reactViewGroup);
+    propsChanged = true;
   }
 
   @ReactProp(name = "manualImpressionsEnabled")
   public void setManualImpressionsEnabled(ReactViewGroup reactViewGroup, boolean value) {
     this.manualImpressionsEnabled = value;
-    requestAd(reactViewGroup);
+    propsChanged = true;
+  }
+
+  @Override
+  public void onAfterUpdateTransaction(@NonNull ReactViewGroup reactViewGroup) {
+    super.onAfterUpdateTransaction(reactViewGroup);
+    if (propsChanged) {
+      requestAd(reactViewGroup);
+    }
+    propsChanged = false;
   }
 
   private BaseAdView initAdView(ReactViewGroup reactViewGroup) {

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.m
@@ -21,9 +21,10 @@
 #import <GoogleMobileAds/GADBannerView.h>
 #import <GoogleMobileAds/GADBannerViewDelegate.h>
 #import <React/RCTUIManager.h>
+#import <React/RCTView.h>
 #import "RNGoogleMobileAdsCommon.h"
 
-@interface BannerComponent : UIView <GADBannerViewDelegate, GADAppEventDelegate>
+@interface BannerComponent : RCTView <GADBannerViewDelegate, GADAppEventDelegate>
 
 @property GADBannerView *banner;
 @property(nonatomic, assign) BOOL requested;
@@ -32,6 +33,7 @@
 @property(nonatomic, copy) NSString *unitId;
 @property(nonatomic, copy) NSDictionary *request;
 @property(nonatomic, copy) NSNumber *manualImpressionsEnabled;
+@property(nonatomic, assign) BOOL propsChanged;
 
 @property(nonatomic, copy) RCTBubblingEventBlock onNativeEvent;
 
@@ -40,6 +42,13 @@
 @end
 
 @implementation BannerComponent
+
+- (void)didSetProps:(NSArray<NSString *> *)changedProps {
+  if (_propsChanged) {
+    [self requestAd];
+  }
+  _propsChanged = false;
+}
 
 - (void)initBanner:(GADAdSize)adSize {
   if (_requested) {
@@ -60,7 +69,7 @@
 
 - (void)setUnitId:(NSString *)unitId {
   _unitId = unitId;
-  [self requestAd];
+  _propsChanged = true;
 }
 
 - (void)setSizes:(NSArray *)sizes {
@@ -74,17 +83,17 @@
     }
   }];
   _sizes = adSizes;
-  [self requestAd];
+  _propsChanged = true;
 }
 
 - (void)setRequest:(NSDictionary *)request {
   _request = request;
-  [self requestAd];
+  _propsChanged = true;
 }
 
 - (void)setManualImpressionsEnabled:(BOOL *)manualImpressionsEnabled {
   _manualImpressionsEnabled = [NSNumber numberWithBool:manualImpressionsEnabled];
-  [self requestAd];
+  _propsChanged = true;
 }
 
 - (void)requestAd {


### PR DESCRIPTION
### Description

Before this change, Banner Ad requested ad multiple times when props are set because we requested ad on every prop changes.
This change batches the prop changes and makes it to request ad only once.

### Related issues

### Release Summary

Batch banner ad props update

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
