### PR TITLE
feat: Get adaptive banner height

### DIFF
--- a/RNGoogleMobileAdsExample/App.tsx
+++ b/RNGoogleMobileAdsExample/App.tsx
@@ -18,6 +18,7 @@ import MobileAds, {
   InterstitialAd,
   TestIds,
   BannerAd,
+  getCurrentOrientationAnchoredAdaptiveBannerHeight,
   BannerAdSize,
   RewardedAd,
   RewardedAdEventType,
@@ -170,6 +171,8 @@ class BannerTest implements Test {
             requestNonPersonalizedAdsOnly: true,
           }}
         />
+        <Text>Current orientation anchored banner height</Text>
+        <Text>{getCurrentOrientationAnchoredAdaptiveBannerHeight()}</Text>
       </View>
     );
   }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeAppModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeAppModule.java
@@ -64,7 +64,7 @@ public class ReactNativeAppModule extends ReactNativeModule {
     int dpWidth = (int) (displayMetrics.widthPixels / displayMetrics.density);
 
     AdSize adaptiveBannerSize =
-      AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(getContext(), dpWidth);
+        AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(getContext(), dpWidth);
     return adaptiveBannerSize.getHeight();
   }
 

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeAppModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeAppModule.java
@@ -17,10 +17,12 @@ package io.invertase.googlemobileads;
  *
  */
 
+import android.util.DisplayMetrics;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.google.android.gms.ads.AdSize;
 import io.invertase.googlemobileads.common.RCTConvert;
 import io.invertase.googlemobileads.common.ReactNativeEvent;
 import io.invertase.googlemobileads.common.ReactNativeEventEmitter;
@@ -53,6 +55,17 @@ public class ReactNativeAppModule extends ReactNativeModule {
     // RCTConvertFirebase.reactNativeAppToWritableMap(reactNativeApp);
     // promise.resolve(reactNativeAppMap);
     promise.resolve(options);
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public int getCurrentOrientationAnchoredAdaptiveBannerHeight() {
+    DisplayMetrics displayMetrics = getContext().getResources().getDisplayMetrics();
+
+    int dpWidth = (int) (displayMetrics.widthPixels / displayMetrics.density);
+
+    AdSize adaptiveBannerSize =
+      AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(getContext(), dpWidth);
+    return adaptiveBannerSize.getHeight();
   }
 
   @ReactMethod

--- a/src/ads/BannerAd.tsx
+++ b/src/ads/BannerAd.tsx
@@ -16,9 +16,15 @@
  */
 
 import React from 'react';
+import { NativeModules } from 'react-native';
 import { BannerAdProps } from '../types/BannerAdProps';
 import { BaseAd } from './BaseAd';
 
 export function BannerAd({ size, ...props }: BannerAdProps) {
   return <BaseAd sizes={[size]} {...props} />;
+}
+
+export function getCurrentOrientationAnchoredAdaptiveBannerHeight() {
+  const { RNAppModule } = NativeModules;
+  return RNAppModule.getCurrentOrientationAnchoredAdaptiveBannerHeight();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export { AppOpenAd } from './ads/AppOpenAd';
 export { InterstitialAd } from './ads/InterstitialAd';
 export { RewardedAd } from './ads/RewardedAd';
 export { RewardedInterstitialAd } from './ads/RewardedInterstitialAd';
-export { BannerAd } from './ads/BannerAd';
+export { BannerAd, getCurrentOrientationAnchoredAdaptiveBannerHeight } from './ads/BannerAd';
 export { GAMBannerAd } from './ads/GAMBannerAd';
 export { GAMInterstitialAd } from './ads/GAMInterstitialAd';
 export { useAppOpenAd } from './hooks/useAppOpenAd';


### PR DESCRIPTION
### Description
At current moment when we use Anchored Adaptive banner and get loading error BannerAd does not take up space on the screen, this may cause to accidental clicks when banner finally loads and google can restrict admob account .
To prevent users from accidental clicks we should reserve screen space for banner before banner shows up, but for anchored adaptive banner  height can variate from 50px to 15% of screen height so we need to get banner height for every device and apply to styles of banner container

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [X] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No


Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
