### PR TITLE
fix(android): send ad size before ad loads

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -51,6 +51,7 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
   private final String EVENT_AD_FAILED_TO_LOAD = "onAdFailedToLoad";
   private final String EVENT_AD_OPENED = "onAdOpened";
   private final String EVENT_AD_CLOSED = "onAdClosed";
+  private final String EVENT_SIZE_CHANGE = "onSizeChange";
   private final String EVENT_APP_EVENT = "onAppEvent";
   private final int COMMAND_ID_RECORD_MANUAL_IMPRESSION = 1;
 
@@ -121,6 +122,15 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
         sizeList.add(ReactNativeGoogleMobileAdsCommon.getAdSize(sizeString, reactViewGroup));
       }
     }
+
+    if (sizeList.size() > 0) {
+      AdSize adSize = sizeList.get(0);
+      WritableMap payload = Arguments.createMap();
+      payload.putDouble("width", adSize.getWidth());
+      payload.putDouble("height", adSize.getHeight());
+      sendEvent(reactViewGroup, EVENT_SIZE_CHANGE, payload);
+    }
+
     sizes = sizeList;
     propsChanged = true;
   }


### PR DESCRIPTION
### Description

Fixes banner ad height not preserving space before loading issue mentioned in #141. 

### Related issues

#141

### Release Summary

Android: Preserve banner ad space before ad loads

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `__tests__e2e__`
  - [x] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Set test container style of banner ad component to `borderWidth: 1` then see if space height changes.

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
