### PR TITLE
fix(rewarded interstitial, ios): fixed false error with valid event type value

### DIFF
--- a/src/ads/MobileAd.ts
+++ b/src/ads/MobileAd.ts
@@ -130,7 +130,8 @@ export abstract class MobileAd implements MobileAdInterface {
     if (
       !(
         isOneOf(type, Object.values(AdEventType)) ||
-        (isOneOf(type, Object.values(RewardedAdEventType)) && (this._type === 'rewarded' || this._type === 'rewarded_interstitial'))
+        (isOneOf(type, Object.values(RewardedAdEventType)) &&
+          (this._type === 'rewarded' || this._type === 'rewarded_interstitial'))
       )
     ) {
       throw new Error(

--- a/src/ads/MobileAd.ts
+++ b/src/ads/MobileAd.ts
@@ -130,7 +130,7 @@ export abstract class MobileAd implements MobileAdInterface {
     if (
       !(
         isOneOf(type, Object.values(AdEventType)) ||
-        (isOneOf(type, Object.values(RewardedAdEventType)) && this._type === 'rewarded')
+        (isOneOf(type, Object.values(RewardedAdEventType)) && (this._type === 'rewarded' || this._type === 'rewarded_interstitial'))
       )
     ) {
       throw new Error(


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Rewarded interstitial ads seem to throw an error when creating an event listener, even though the event type is valid.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

Fixes #147

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

The expected event type is `rewarded_interstitial`, although error checking 

Before:
![Screenshot 2022-05-12 at 16 08 11](https://user-images.githubusercontent.com/5025488/168107644-ede4ac6d-85a5-42fd-aa4e-635b918d3c9c.png)

After:
![Screenshot 2022-05-12 at 16 07 51](https://user-images.githubusercontent.com/5025488/168107697-6df41f55-4180-4c35-a5e5-1c804f62a2d1.png)


---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
