### PR TITLE
fix: fix ad inspector callback error

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.java
@@ -179,8 +179,9 @@ public class ReactNativeGoogleMobileAdsModule extends ReactNativeModule {
                         }
                         rejectPromiseWithCodeAndMessage(
                             promise, code, adInspectorError.getMessage());
+                      } else {
+                        promise.resolve(null);
                       }
-                      promise.resolve(null);
                     }
                   });
             });

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsModule.m
@@ -115,8 +115,9 @@ RCT_EXPORT_METHOD(openAdInspector
                                                         stringWithFormat:@"CODE_%d", error.code],
                                                     @"message" : error.description,
                                                   } mutableCopy]];
+                           } else {
+                             resolve(nil);
                            }
-                           resolve(nil);
                          }];
 }
 


### PR DESCRIPTION
### Description

If ad inspector got error while opening, the following error occured:

`No callback found with cbID # and callID # for RNGoogleMobileAdsModule.openAdInspector - most likely the callback was already invoked.`

This was because we are resolving the promise even the promise is rejected already.

### Related issues

### Release Summary

Fix ad inspector callback error

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
