### PR TITLE
feat: add ppid option to request options

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
@@ -183,6 +183,10 @@ public class ReactNativeGoogleMobileAdsCommon {
       }
     }
 
+    if (adRequestOptions.hasKey("publisherProvidedId")) {
+      builder.setPublisherProvidedId(Objects.requireNonNull(adRequestOptions.getString("publisherProvidedId")));
+    }
+
     return builder.build();
   }
 

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
@@ -184,7 +184,8 @@ public class ReactNativeGoogleMobileAdsCommon {
     }
 
     if (adRequestOptions.hasKey("publisherProvidedId")) {
-      builder.setPublisherProvidedId(Objects.requireNonNull(adRequestOptions.getString("publisherProvidedId")));
+      builder.setPublisherProvidedId(
+          Objects.requireNonNull(adRequestOptions.getString("publisherProvidedId")));
     }
 
     return builder.build();

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.m
@@ -82,7 +82,7 @@ NSString *const GOOGLE_MOBILE_ADS_EVENT_REWARDED_EARNED_REWARD = @"rewarded_earn
   if (adRequestOptions[@"customTargeting"]) {
     request.customTargeting = adRequestOptions[@"customTargeting"];
   }
-  
+
   if (adRequestOptions[@"publisherProvidedId"]) {
     request.publisherProvidedID = adRequestOptions[@"publisherProvidedId"];
   }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.m
@@ -82,6 +82,10 @@ NSString *const GOOGLE_MOBILE_ADS_EVENT_REWARDED_EARNED_REWARD = @"rewarded_earn
   if (adRequestOptions[@"customTargeting"]) {
     request.customTargeting = adRequestOptions[@"customTargeting"];
   }
+  
+  if (adRequestOptions[@"publisherProvidedId"]) {
+    request.publisherProvidedID = adRequestOptions[@"publisherProvidedId"];
+  }
 
   return request;
 }

--- a/src/types/RequestOptions.ts
+++ b/src/types/RequestOptions.ts
@@ -93,4 +93,11 @@ export interface RequestOptions {
    * See [Google Mobile SDK Docs](https://developers.google.com/admob/android/ssv) for more information.
    */
   serverSideVerificationOptions?: ServerSideVerificationOptions;
+
+  /**
+   * Publisher provided identifier (PPID) for use in frequency capping, audience segmentation and targeting,
+   * sequential ad rotation, and other audience-based ad delivery controls across devices.
+   * See [this article](https://support.google.com/admanager/answer/2880055) for more information.
+   */
+  publisherProvidedId?: string;
 }

--- a/src/validateAdRequestOptions.ts
+++ b/src/validateAdRequestOptions.ts
@@ -126,5 +126,12 @@ export function validateAdRequestOptions(options?: RequestOptions) {
     out.customTargeting = options.customTargeting;
   }
 
+  if (options.publisherProvidedId) {
+    if (!isString(options.publisherProvidedId)) {
+      throw new Error("'options.publisherProvidedId' expected a string value");
+    }
+    out.publisherProvidedId = options.publisherProvidedId;
+  }
+
   return out;
 }


### PR DESCRIPTION
### Description

This PR adds `publisherProvidedId` property to RequestOptions.
Related link: https://developers.google.com/ad-manager/mobile-ads-sdk/android/targeting#publisher_provided_identifiers

### Related issues

### Release Summary

Added `publisherProvidedId` property to request options

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
