### PR TITLE
docs: fix banner ad doc hidden for ad block users

### DIFF
--- a/docs/displaying-ads.mdx
+++ b/docs/displaying-ads.mdx
@@ -396,7 +396,7 @@ If you request an Advert as in the example above, AdMob will call your server wi
 
 You still need to verify these incoming requests yourself to ensure they are genuine. To learn more about callback parameters and verifying, see the [AdMob SDK Server Side Verification(SSV) documentation](https://developers.google.com/admob/android/rewarded-video-ssv).
 
-## Banner Ads
+## Banner Ads (component)
 
 Banner ads are partial adverts which can be integrated within your existing application. Unlike Interstitial and Rewarded Ads,
 a Banner only takes up a limited area of the application and displays an advert within the area. This allows you to integrate


### PR DESCRIPTION
### Description

This fixes banner ad doc is not showing for ad block users.

### Related issues

#163 

### Release Summary

fix banner ad doc hidden for ad block users

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
