### PR TITLE
feat(ios, sdk)!: use google-mobile-ads-sdk 9.6.0 requires Xcode >= 13.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "sdkVersions": {
     "ios": {
-      "googleMobileAds": "9.3.0",
+      "googleMobileAds": "9.6.0",
       "googleUmp": "2.0.0"
     },
     "android": {


### PR DESCRIPTION
### Description

Update to new minor version of iOS SDK

### Related issues

May fix #173 - needs testing :eyes: @RodolfoGS

### Release Summary

Should be released at same time as bump to android SDK which is a breaking change as minSdkVersion goes to 19 there:

Why combine in one breaking release? This change has this:

> Updated minimum supported Xcode version to 13.2.1.

Which is a tiny break, but still a break. Do them at same time I think

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
