### PR TITLE
docs(ios, frameworks): document how to set up static frameworks

### DIFF
--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -93,7 +93,7 @@ The method returns an `AdsConsentInfo` interface, which provides information abo
   - `OBTAINED`: User consent already obtained.
 - **isConsentFormAvailable**: A boolean value. If `true` a consent form is available.
 
-**Note:** The return status of this call is the status of *form presentation and response collection*, **not
+**Note:** The return status of this call is the status of _form presentation and response collection_, **not
 the the actual user consent**. It simply indicates if you now have a consent response to decode.
 (_i.e._ if user consent is **required**, the form has been presented, and user has
 **denied** the consent, the status returned by this method will be `OBTAINED`,
@@ -197,4 +197,5 @@ UMP SDK for [Android](https://developers.google.com/admob/ump/android/quick-star
 [iOS](https://developers.google.com/admob/ump/ios/quick-start).
 
 <!-- links -->
-[Inspecting consent choices]: #inspecting-consent-choices
+
+[inspecting consent choices]: #inspecting-consent-choices

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,6 +7,10 @@ yarn add react-native-google-mobile-ads
 
 > On Android, before releasing your app, you must select _Yes, my app contains ads_ in the Google Play Store, Policy, App content, Manage under Ads.
 
+## Optionally configure iOS static frameworks
+
+On iOS if you need to use static frameworks (that is, `use_frameworks!` in your `Podfile`) you must add the variable `$RNGoogleMobileAdsAsStaticFramework = true` to the targets in your `Podfile`. You may need this if you use this module in combination with react-native-firebase v15 and higher since it requires `use_frameworks!`.
+
 ## What does it do
 
 The AdMob module allows you to display adverts to your users. All adverts are served over the Google AdMob network, meaning
@@ -39,7 +43,7 @@ Before you are able to display ads to your users, you must have a [Google AdMob 
 "Apps" menu item, create or choose an existing Android/iOS app. Each app platform exposes a unique account ID which needs to
 be added to the project.
 
-> Attempting to build your app without a valid App ID may cause a crash during build.
+> Attempting to build your app without a valid App ID in `app.json` will cause the app to crash on start or fail to build.
 
 Under the "App settings" menu item, you can find the "App ID":
 


### PR DESCRIPTION
### Description

it was possible before but never documented, it's important now that react-native-firebase v15+ requires `use_frameworks!`

### Related issues

Related #173

### Release Summary
A single conventional commit

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

I ran `yarn lint:markdown:check` (also `yarn lint:markdown:fix` which altered a couple other things...)

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
