### PR TITLE
feat(android, sdk)!: android ads sdk v21, requires android minSdkVersion 19+

### DIFF
--- a/RNGoogleMobileAdsExample/app.json
+++ b/RNGoogleMobileAdsExample/app.json
@@ -5,6 +5,8 @@
     "android_app_id": "ca-app-pub-3940256099942544~3347511713",
     "ios_app_id": "ca-app-pub-3940256099942544~1458002511",
     "delay_app_measurement_init": false,
+    "optimize_initialization": true,
+    "optimize_ad_loading": true,
     "user_tracking_usage_description": "This identifier will be used to deliver personalized ads to you."
   }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,10 +57,14 @@ apply from: file("./app-json.gradle")
 
 def appJSONGoogleMobileAdsAppIDString = ""
 def appJSONGoogleMobileAdsDelayAppMeasurementInitBool = false
+def appJSONGoogleMobileAdsOptimizeInitializationBool = true
+def appJSONGoogleMobileAdsOptimizeAdLoadingBool = true
 
 if (rootProject.ext.googleMobileAdsJson) {
   appJSONGoogleMobileAdsAppIDString = rootProject.ext.googleMobileAdsJson.getStringValue("android_app_id", "")
   appJSONGoogleMobileAdsDelayAppMeasurementInitBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("delay_app_measurement_init", false)
+  appJSONGoogleMobileAdsOptimizeInitializationBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("optimize_initialization", true)
+  appJSONGoogleMobileAdsOptimizeAdLoadingBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("optimize_ad_loading", true)
 }
 
 if (!appJSONGoogleMobileAdsAppIDString) {
@@ -72,7 +76,9 @@ android {
     multiDexEnabled true
     manifestPlaceholders = [
       appJSONGoogleMobileAdsAppID                  : appJSONGoogleMobileAdsAppIDString,
-      appJSONGoogleMobileAdsDelayAppMeasurementInit: appJSONGoogleMobileAdsDelayAppMeasurementInitBool
+      appJSONGoogleMobileAdsDelayAppMeasurementInit: appJSONGoogleMobileAdsDelayAppMeasurementInitBool,
+      appJSONGoogleMobileAdsOptimizeInitialization : appJSONGoogleMobileAdsOptimizeInitializationBool,
+      appJSONGoogleMobileAdsOptimizeAdLoading      : appJSONGoogleMobileAdsOptimizeAdLoadingBool
     ]
   }
   lintOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -13,5 +13,11 @@
       <meta-data
         android:name="com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT"
         android:value="${appJSONGoogleMobileAdsDelayAppMeasurementInit}"/>
+      <meta-data
+        android:name="com.google.android.gms.ads.flag.OPTIMIZE_INITIALIZATION"
+        android:value="${appJSONGoogleMobileAdsOptimizeInitialization}"/>
+      <meta-data
+        android:name="com.google.android.gms.ads.flag.OPTIMIZE_AD_LOADING"
+        android:value="${appJSONGoogleMobileAdsOptimizeAdLoading}"/>
     </application>
 </manifest>

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
       "googleUmp": "2.0.0"
     },
     "android": {
-      "minSdk": 16,
+      "minSdk": 19,
       "targetSdk": 30,
       "compileSdk": 31,
       "buildTools": "31.0.0",
-      "googleMobileAds": "20.6.0",
+      "googleMobileAds": "21.0.0",
       "googleUmp": "2.0.0"
     }
   },


### PR DESCRIPTION
### Description

Update to the new underlying SDK. This had no code breaking changes but does bump the minSdkVersion, so for that it is a breaking change

I also implemented the new background-thread optimization feature for android via app.json toggles to fill in the AndroidManifest.xml items

### Related issues

Fixes #175
Unblocks #174 

### Release Summary

conventional commits including breaking change notice

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No

### Test Plan

Ran all the tests locally, examined lint output and grepped codebase for deprecated items from the upstream migration doc, all clean

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
