### PR TITLE
fix(android, build): correct kotlin plugin dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,10 @@
 import io.invertase.gradle.common.PackageJson
 
 buildscript {
+  ext.getExtOrDefault = {name, version ->
+    return rootProject.ext.has(name) ? rootProject.ext.get(name) : version
+  }
+
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
   // module dependency in an application project.
@@ -12,7 +16,15 @@ buildscript {
 
     dependencies {
       classpath("com.android.tools.build:gradle:7.0.4")
-      classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}"
+      classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${getExtOrDefault('kotlinVersion', '1.6.10')}"
+    }
+  } else {
+    repositories {
+      mavenCentral()
+    }
+
+    dependencies {
+      classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${getExtOrDefault('kotlinVersion', '1.6.10')}"
     }
   }
 }
@@ -114,6 +126,3 @@ ReactNative.shared.applyDefaultExcludes()
 ReactNative.module.applyAndroidVersions()
 ReactNative.module.applyReactNativeDependency("api")
 
-def safeExtGet(prop, fallback) {
-  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-}


### PR DESCRIPTION
### Description

@birdofpreyru noticed and helpfully pointed out that our kotlin plugin build dependency wasn't correct, and I think this corrects it 

### Related issues

Fixes #180 

### Release Summary

Single conventional commit

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

CI should handle but hopefully @birdofpreyru can also try the patch-package set to verify since he's got this reproducing locally :pray: 

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
