### PR TITLE
feat(hooks)!: automatically set isLoaded to false

### DIFF
--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -84,7 +84,7 @@ Return values of the hook are:
 
 | Name           | Type                               | Description                                                                                                        |
 | :------------- | :--------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
-| isLoaded       | boolean                            | Whether the ad is loaded and ready to to be shown to the user. Automatically set to false when the ad is opened.   |
+| isLoaded       | boolean                            | Whether the ad is loaded and ready to to be shown to the user. Automatically set to false when the ad was shown.   |
 | isOpened       | boolean                            | Whether the ad is opened. The value is remained `true` even after the ad is closed unless **new ad is requested**. |
 | isClosed       | boolean                            | Whether your ad is dismissed.                                                                                      |
 | isShowing      | boolean                            | Whether your ad is showing. The value is equal with `isOpened && !isClosed`.                                       |

--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -84,7 +84,7 @@ Return values of the hook are:
 
 | Name           | Type                               | Description                                                                                                        |
 | :------------- | :--------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
-| isLoaded       | boolean                            | Whether the ad is loaded and ready to to be shown to the user.                                                     |
+| isLoaded       | boolean                            | Whether the ad is loaded and ready to to be shown to the user. Automatically set to false when the ad is opened.   |
 | isOpened       | boolean                            | Whether the ad is opened. The value is remained `true` even after the ad is closed unless **new ad is requested**. |
 | isClosed       | boolean                            | Whether your ad is dismissed.                                                                                      |
 | isShowing      | boolean                            | Whether your ad is showing. The value is equal with `isOpened && !isClosed`.                                       |

--- a/src/hooks/useFullScreenAd.ts
+++ b/src/hooks/useFullScreenAd.ts
@@ -73,7 +73,7 @@ export function useFullScreenAd<
           setState({ isLoaded: true });
           break;
         case AdEventType.OPENED:
-          setState({ isOpened: true });
+          setState({ isOpened: true, isLoaded: false });
           break;
         case AdEventType.CLOSED:
           setState({ isClosed: true });

--- a/src/hooks/useFullScreenAd.ts
+++ b/src/hooks/useFullScreenAd.ts
@@ -73,10 +73,10 @@ export function useFullScreenAd<
           setState({ isLoaded: true });
           break;
         case AdEventType.OPENED:
-          setState({ isOpened: true, isLoaded: false });
+          setState({ isOpened: true });
           break;
         case AdEventType.CLOSED:
-          setState({ isClosed: true });
+          setState({ isClosed: true, isLoaded: false });
           break;
         case AdEventType.CLICKED:
           setState({ isClicked: true });


### PR DESCRIPTION
### Description

I find it weird that `isLoaded` in hooks doesn't change value when ad is shown. In fact, the value `isLoaded = true` after ad has been shown is wrong since a new ad has not been loaded and calling `show` will fail.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- ~~My change includes tests;~~
  - [x] ~~`e2e` tests added or updated in `__tests__e2e__`~~
  - [x] ~~`jest` tests added or updated in `__tests__`~~
- [x] ~~I have updated TypeScript types that are affected by my change.~~
- This is a breaking change;
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
I wanted to add some tests on `useRewardedAd` hook but I had this error
```bash
    TypeError: RNAppModule.eventsNotifyReady is not a function

      34 |   ) {
      35 |     if (!this.ready) {
    > 36 |       RNAppModule.eventsNotifyReady(true);
         |                   ^
      37 |       this.ready = true;
      38 |     }
      39 |     RNAppModule.eventsAddListener(eventType);

      at GANativeEventEmitter.eventsNotifyReady [as addListener] (src/internal/GoogleMobileAdsNativeEventEmitter.ts:36:19)
      at addListener (src/internal/registry/nativeModule.ts:146:39)
      at subscribeToNativeModuleEvent (src/internal/registry/nativeModule.ts:124:7)
      at initialiseNativeModule (src/internal/registry/nativeModule.ts:203:10)
      at MobileAdsModule.get (src/internal/Module.ts:52:26)
      at MobileAdsModule.native [as initialize] (src/MobileAds.ts:57:17)
      at initialize (__tests__/rewarded.test.tsx:7:19)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:294:22)
      at Generator.next (node_modules/regenerator-runtime/runtime.js:119:21)
```

`rewarded.test.tsx`
```typescript
import { renderHook, act } from '@testing-library/react-hooks/native';
import MobileAds, { useRewardedAd } from '../src';

describe('Admob Rewarded', () => {
  describe('useRewardedAd() hook', function () {
    it('has false as isLoaded initial value', async function () {
      MobileAds().initialize();
      const { result } = renderHook(() => useRewardedAd('123'));

      expect(result.current.isLoaded).toBe(false);

      act(() => {
        result.current.load();
      });

      expect(result.current.isLoaded).toBe(true);
    });
  });
});
```

And I had plan to test if calling `show` will set `isLoaded` to `false`.

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter

🔥 