### PR TITLE
fix(android, sdk): passing custom targeting as array of string instead of string

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
@@ -178,7 +178,7 @@ public class ReactNativeGoogleMobileAdsCommon {
 
       for (Map.Entry<String, Object> entry : customTargeting.entrySet()) {
         String key = entry.getKey();
-        String value = (String) entry.getValue();
+        ArrayList<String> value = (ArrayList<String>) entry.getValue();
         builder.addCustomTargeting(key, value);
       }
     }

--- a/src/types/RequestOptions.ts
+++ b/src/types/RequestOptions.ts
@@ -70,7 +70,7 @@ export interface RequestOptions {
    *
    * Takes an array of string key/value pairs.
    */
-  customTargeting?: { [key: string]: string };
+  customTargeting?: { [key: string]: string[] };
 
   /**
    * Sets the request agent string to identify the ad request's origin. Third party libraries that reference the Mobile

--- a/src/types/RequestOptions.ts
+++ b/src/types/RequestOptions.ts
@@ -70,7 +70,7 @@ export interface RequestOptions {
    *
    * Takes an array of string key/value pairs.
    */
-  customTargeting?: { [key: string]: string[] };
+  customTargeting?: { [key: string]: string | string[] };
 
   /**
    * Sets the request agent string to identify the ad request's origin. Third party libraries that reference the Mobile


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
When passing customTargeting as Array of string instead of string the app is crashed.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
https://developers.google.com/android/reference/com/google/android/gms/ads/admanager/AdManagerAdRequest.Builder#public-admanageradrequest.builder-addcustomtargeting-string-key,-liststring-values
---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
