### PR TITLE
fix(ios, config): fix typo in ios_app_id error message

### DIFF
--- a/ios_config.sh
+++ b/ios_config.sh
@@ -131,7 +131,7 @@ if ! [[ -f "${_TARGET_PLIST}" ]]; then
 fi
 
 if ! [[ $_IOS_APP_ID ]]; then
-  echo "error: ios_appd_id key not found in react-native-google-mobile-ads key in app.json. App will crash without it."
+  echo "error: ios_app_id key not found in react-native-google-mobile-ads key in app.json. App will crash without it."
   exit 1
 fi
 


### PR DESCRIPTION

### Description

The error message had a typo, which is not a great developer experience...

### Related issues

Noted in #219

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

None, visual inspection should be sufficient

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
