### PR TITLE
fix(android, release): fix proguard-related crashes in android release mode

### DIFF
--- a/RNGoogleMobileAdsExample/App.tsx
+++ b/RNGoogleMobileAdsExample/App.tsx
@@ -67,7 +67,11 @@ class AppOpenTest implements Test {
         <Button
           title="Show App Open Ad"
           onPress={() => {
-            appOpen.show();
+            try {
+              appOpen.show();
+            } catch (e) {
+              console.log(`${Platform.OS} app open show error: ${e}`);
+            }
           }}
         />
       </View>
@@ -125,7 +129,11 @@ class InterstitialTest implements Test {
         <Button
           title="Show Interstitial"
           onPress={() => {
-            interstitial.show();
+            try {
+              interstitial.show();
+            } catch (e) {
+              console.log(`${Platform.OS} app open show error: ${e}`);
+            }
           }}
         />
       </View>
@@ -225,7 +233,11 @@ class RewardedTest implements Test {
         <Button
           title="Show Rewarded"
           onPress={() => {
-            rewarded.show();
+            try {
+              rewarded.show();
+            } catch (e) {
+              console.log(`${Platform.OS} app open show error: ${e}`);
+            }
           }}
         />
       </View>
@@ -291,7 +303,11 @@ class RewardedInterstitialTest implements Test {
         <Button
           title="Show Rewarded Interstitial"
           onPress={() => {
-            rewardedInterstitial.show();
+            try {
+              rewardedInterstitial.show();
+            } catch (e) {
+              console.log(`${Platform.OS} app open show error: ${e}`);
+            }
           }}
         />
       </View>

--- a/RNGoogleMobileAdsExample/App.tsx
+++ b/RNGoogleMobileAdsExample/App.tsx
@@ -40,7 +40,6 @@ class AppOpenTest implements Test {
   adLoaded = false;
 
   constructor() {
-    appOpen.load();
     // Current no way in jet-next to re-render on async completion or to delay render? But still can log it
     this.adListener = appOpen.addAdEventsListener(({type, payload}) => {
       console.log(`${Platform.OS} app open ad event: ${type}`);
@@ -64,6 +63,17 @@ class AppOpenTest implements Test {
   render(onMount: (component: any) => void): React.ReactNode {
     return (
       <View style={styles.testSpacing} ref={onMount}>
+        <Button
+          title="Load App Open Ad"
+          onPress={() => {
+            try {
+              appOpen.load();
+            } catch (e) {
+              console.log(`${Platform.OS} app open load error: ${e}`);
+            }
+          }}
+        />
+        <Text>Loaded? {this.adLoaded ? 'true' : 'false'}</Text>
         <Button
           title="Show App Open Ad"
           onPress={() => {
@@ -102,7 +112,6 @@ class InterstitialTest implements Test {
   adLoaded = false;
 
   constructor() {
-    interstitial.load();
     // Current no way in jet-next to re-render on async completion or to delay render? But still can log it
     this.adListener = interstitial.addAdEventsListener(({type, payload}) => {
       console.log(`${Platform.OS} interstitial ad event: ${type}`);
@@ -126,6 +135,17 @@ class InterstitialTest implements Test {
   render(onMount: (component: any) => void): React.ReactNode {
     return (
       <View style={styles.testSpacing} ref={onMount}>
+        <Button
+          title="Load Interstitial"
+          onPress={() => {
+            try {
+              interstitial.load();
+            } catch (e) {
+              console.log(`${Platform.OS} interstitial load error: ${e}`);
+            }
+          }}
+        />
+        <Text>Loaded? {this.adLoaded ? 'true' : 'false'}</Text>
         <Button
           title="Show Interstitial"
           onPress={() => {
@@ -203,7 +223,6 @@ class RewardedTest implements Test {
   adLoaded = false;
 
   constructor() {
-    rewarded.load();
     // Current no way in jet-next to re-render on async completion or to delay render? But still can log it
     this.adListener = rewarded.addAdEventsListener(({type, payload}) => {
       console.log(`${Platform.OS} rewarded ad event: ${type}`);
@@ -230,6 +249,17 @@ class RewardedTest implements Test {
   render(onMount: (component: any) => void): React.ReactNode {
     return (
       <View style={styles.testSpacing} ref={onMount}>
+        <Button
+          title="Load Rewarded"
+          onPress={() => {
+            try {
+              rewarded.load();
+            } catch (e) {
+              console.log(`${Platform.OS} rewarded load error: ${e}`);
+            }
+          }}
+        />
+        <Text>Loaded? {this.adLoaded ? 'true' : 'false'}</Text>
         <Button
           title="Show Rewarded"
           onPress={() => {
@@ -269,7 +299,6 @@ class RewardedInterstitialTest implements Test {
   adLoaded = false;
 
   constructor() {
-    rewardedInterstitial.load();
     // Current no way in jet-next to re-render on async completion or to delay render? But still can log it
     this.adListener = rewardedInterstitial.addAdEventsListener(
       ({type, payload}) => {
@@ -300,6 +329,19 @@ class RewardedInterstitialTest implements Test {
   render(onMount: (component: any) => void): React.ReactNode {
     return (
       <View style={styles.testSpacing} ref={onMount}>
+        <Button
+          title="Load Rewarded Interstitial"
+          onPress={() => {
+            try {
+              rewardedInterstitial.load();
+            } catch (e) {
+              console.log(
+                `${Platform.OS} rewarded interstitial load error: ${e}`,
+              );
+            }
+          }}
+        />
+        <Text>Loaded? {this.adLoaded ? 'true' : 'false'}</Text>
         <Button
           title="Show Rewarded Interstitial"
           onPress={() => {
@@ -739,7 +781,6 @@ class GAMInterstitialTest implements Test {
   adLoaded = false;
 
   constructor() {
-    gamInterstitial.load();
     // Current no way in jet-next to re-render on async completion or to delay render? But still can log it
     this.adListener = gamInterstitial.addAdEventsListener(({type, payload}) => {
       console.log(`${Platform.OS} GAM interstitial ad event: ${type}`);
@@ -775,8 +816,18 @@ class GAMInterstitialTest implements Test {
     return (
       <View style={styles.testSpacing} ref={onMount}>
         <Button
-          title="Show Interstitial"
-          disabled={!this.adLoaded}
+          title="Load GAM Interstitial"
+          onPress={() => {
+            try {
+              gamInterstitial.load();
+            } catch (e) {
+              console.log(`${Platform.OS} GAM Interstitial load error: ${e}`);
+            }
+          }}
+        />
+        <Text>Loaded? {this.adLoaded ? 'true' : 'false'}</Text>
+        <Button
+          title="Show GAM Interstitial"
           onPress={() => {
             gamInterstitial.show();
           }}

--- a/RNGoogleMobileAdsExample/android/app/build.gradle
+++ b/RNGoogleMobileAdsExample/android/app/build.gradle
@@ -97,7 +97,7 @@ def enableSeparateBuildPerCPUArchitecture = false
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore.
@@ -230,6 +230,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
+            proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAdHelper.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAdHelper.kt
@@ -18,88 +18,63 @@ package io.invertase.googlemobileads
  */
 
 import android.app.Activity
-import com.google.android.gms.ads.AdLoadCallback
 import com.google.android.gms.ads.FullScreenContentCallback
-import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.OnUserEarnedRewardListener
-import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAd
 import com.google.android.gms.ads.admanager.AppEventListener
 import com.google.android.gms.ads.appopen.AppOpenAd
 import com.google.android.gms.ads.interstitial.InterstitialAd
-import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
 import com.google.android.gms.ads.rewarded.RewardItem
 import com.google.android.gms.ads.rewarded.RewardedAd
-import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
-import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAdLoadCallback
 
 class ReactNativeGoogleMobileAdsAdHelper<T>(private val ad: T) {
   fun show(activity: Activity, onUserEarnedRewardListener: OnUserEarnedRewardListener?) {
     when (ad) {
-      is AppOpenAd, is InterstitialAd -> {
-        val method = ad.javaClass.getMethod("show", Activity::class.java)
-        method.invoke(ad, activity)
-      }
-      is RewardedAd, is RewardedInterstitialAd -> {
-        val method = ad.javaClass.getMethod(
-          "show",
-          Activity::class.java,
-          OnUserEarnedRewardListener::class.java
-        )
-        method.invoke(ad, activity, onUserEarnedRewardListener)
-      }
+      is AppOpenAd -> ad.show(activity)
+      is InterstitialAd -> ad.show(activity)
+      is RewardedAd -> onUserEarnedRewardListener?.let { ad.show(activity, it) }
+      is RewardedInterstitialAd -> onUserEarnedRewardListener?.let { ad.show(activity, it) }
     }
   }
 
   fun setFullScreenContentCallback(fullScreenContentCallback: FullScreenContentCallback) {
     when (ad) {
-      is AppOpenAd, is InterstitialAd, is RewardedAd, is RewardedInterstitialAd -> {
-        val method = ad.javaClass.getMethod(
-          "setFullScreenContentCallback",
-          FullScreenContentCallback::class.java
-        )
-        method.invoke(ad, fullScreenContentCallback)
-      }
+      is AppOpenAd -> ad.fullScreenContentCallback = fullScreenContentCallback
+      is InterstitialAd -> ad.fullScreenContentCallback = fullScreenContentCallback
+      is RewardedAd -> ad.fullScreenContentCallback = fullScreenContentCallback
+      is RewardedInterstitialAd -> ad.fullScreenContentCallback = fullScreenContentCallback
     }
   }
 
   fun setAppEventListener(appEventListener: AppEventListener) {
     if (ad is AdManagerInterstitialAd) {
-      val method = ad.javaClass.getMethod("setAppEventListener", AppEventListener::class.java)
-      method.invoke(ad, appEventListener)
+      ad.appEventListener = appEventListener
     }
   }
 
   fun setImmersiveMode(enabled: Boolean) {
     when (ad) {
-      is AppOpenAd, is InterstitialAd, is RewardedAd, is RewardedInterstitialAd -> {
-        val method = ad.javaClass.getMethod("setImmersiveMode", Boolean::class.javaPrimitiveType)
-        method.invoke(ad, enabled)
-      }
+      is AppOpenAd -> ad.setImmersiveMode(enabled)
+      is InterstitialAd -> ad.setImmersiveMode(enabled)
+      is RewardedAd -> ad.setImmersiveMode(enabled)
+      is RewardedInterstitialAd -> ad.setImmersiveMode(enabled)
     }
   }
 
   fun setServerSideVerificationOptions(serverSideVerificationOptions: ServerSideVerificationOptions) {
     when (ad) {
-      is RewardedAd, is RewardedInterstitialAd -> {
-        val method = ad.javaClass.getMethod(
-          "setServerSideVerificationOptions",
-          ServerSideVerificationOptions::class.java
-        )
-        method.invoke(ad, serverSideVerificationOptions)
-      }
+      is RewardedAd -> ad.setServerSideVerificationOptions(serverSideVerificationOptions)
+      is RewardedInterstitialAd -> ad.setServerSideVerificationOptions(serverSideVerificationOptions)
     }
   }
 
   val rewardItem: RewardItem
     get() {
       when (ad) {
-        is RewardedAd, is RewardedInterstitialAd -> {
-          val method = ad.javaClass.getMethod("getRewardItem")
-          return method.invoke(ad) as RewardItem
-        }
+        is RewardedAd -> return ad.rewardItem
+        is RewardedInterstitialAd -> return ad.rewardItem
       }
       throw IllegalStateException("Ad type not supported")
     }

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -61,6 +61,12 @@ rm -f android/settings.gradle??
 sed -i -e $'s/react_native_post_install(installer)/react_native_post_install(installer)\\\n\\\n    # quiet non-module warnings - only interested in google-mobile-ads warnings\\\n    installer.pods_project.targets.each do |target|\\\n      if !target.name.include? "react-native-google-mobile-ads"\\\n        target.build_configurations.each do |config|\\\n          config.build_settings["GCC_WARN_INHIBIT_ALL_WARNINGS"] = "YES"\\\n        end\\\n      end\\\n    end/' ios/Podfile
 rm -f ios/Podfile??
 
+# We want to easily test normal android release build setup, which is with proguard on
+sed -i -e $'s/def enableProguardInReleaseBuilds = false/def enableProguardInReleaseBuilds = true/' android/app/build.gradle
+rm -f android/app/build.gradle??
+sed -i -e $'s/proguardFiles/proguardFile "${rootProject.projectDir}\/..\/node_modules\/detox\/android\/detox\/proguard-rules-app.pro"\\\n            proguardFiles/' android/app/build.gradle
+rm -f android/app/build.gradle??
+
 # This is just a speed optimization, very optional, but asks xcodebuild to use clang and clang++ without the fully-qualified path
 # That means that you can then make a symlink in your path with clang or clang++ and have it use a different binary
 # In that way you can install ccache or buildcache and get much faster compiles...


### PR DESCRIPTION
### Description

The android ad helper object was using reflection to access a bunch of admob SDK methods, which means that proguard is not able to determine the classes were needed so it was either obfuscating the names (so they weren't found) or stripping the classes (so they were not found)

Either way, it is much simpler to just refactor the code to use concrete APIs vs reflection, then no proguard tricks are required

Related: our test app did not have much support for android release mode testing so I added a bunch of stuff there


### Related issues

Fixes #183 
Fixes #241 
Related #161 (load events not coming through in release mode?)

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

I added some targets to facilitate testing:
- yarn tests:android:build-release
- yarn tests:android:build-release:windows
- yarn tests:android:test-release
- yarn tests:android:test-release:windows

I altered refresh-example to turn on minification in release mode for android

Now you can run the test app in release mode with proguard effects, which showed the error if you click on any of the full screen ads

With my changes you. no longer get an error, but in release mode you don't see whether the full screen ads load or not?

So I added some code in the example App.tsx to expose the loaded state and let you manually load.

Now in release mode you can load each of the full screen ads and check them, seems to work, though the ad events is still an open issue

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
