### PR TITLE
feat: allow load to be called again after error

### DIFF
--- a/__tests__/interstitial.test.ts
+++ b/__tests__/interstitial.test.ts
@@ -1,4 +1,5 @@
 import { AdEventType, InterstitialAd } from '../src';
+import { NativeModules } from 'react-native';
 
 describe('Google Mobile Ads Interstitial', function () {
   describe('createForAdRequest', function () {
@@ -22,6 +23,65 @@ describe('Google Mobile Ads Interstitial', function () {
       expect(i.constructor.name).toEqual('InterstitialAd');
       expect(i.adUnitId).toEqual('abc');
       expect(i.loaded).toEqual(false);
+    });
+
+    describe('load()', () => {
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('does call native load method', () => {
+        const ad = InterstitialAd.createForAdRequest('abc');
+
+        ad.load();
+        expect(NativeModules.RNGoogleMobileAdsModule.interstitialLoad).toBeCalledTimes(1);
+      });
+
+      it('does nothing if ad currently loading', () => {
+        const ad = InterstitialAd.createForAdRequest('abc');
+
+        ad.load();
+        expect(NativeModules.RNGoogleMobileAdsModule.interstitialLoad).toBeCalledTimes(1);
+
+        ad.load();
+        expect(NativeModules.RNGoogleMobileAdsModule.interstitialLoad).toBeCalledTimes(1);
+      });
+
+      it('does nothing if ad is already loaded', () => {
+        const ad = InterstitialAd.createForAdRequest('abc');
+
+        // @ts-ignore
+        ad._handleAdEvent({ body: { type: AdEventType.LOADED } });
+
+        ad.load();
+        expect(NativeModules.RNGoogleMobileAdsModule.interstitialLoad).not.toBeCalled();
+      });
+
+      it('can be called again after ad was closed', () => {
+        const ad = InterstitialAd.createForAdRequest('abc');
+
+        ad.load();
+        expect(NativeModules.RNGoogleMobileAdsModule.interstitialLoad).toBeCalledTimes(1);
+
+        // @ts-ignore
+        ad._handleAdEvent({ body: { type: AdEventType.CLOSED } });
+
+        ad.load();
+        expect(NativeModules.RNGoogleMobileAdsModule.interstitialLoad).toBeCalledTimes(2);
+      });
+
+      it('can be called again after ad failed to load', () => {
+        const ad = InterstitialAd.createForAdRequest('abc');
+
+        ad.load();
+        expect(NativeModules.RNGoogleMobileAdsModule.interstitialLoad).toBeCalledTimes(1);
+
+        // @ts-ignore
+        ad._handleAdEvent({ body: { type: AdEventType.ERROR } });
+
+        ad.load();
+        expect(NativeModules.RNGoogleMobileAdsModule.interstitialLoad).toBeCalledTimes(2);
+      });
     });
 
     describe('show', function () {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -12,12 +12,15 @@ jest.doMock('react-native', () => {
         RNAppModule: {
           addListener: jest.fn(),
           removeListeners: jest.fn(),
+          eventsAddListener: jest.fn(),
+          eventsNotifyReady: jest.fn(),
         },
         RNGoogleMobileAdsModule: {
           addListener: jest.fn(),
           removeListeners: jest.fn(),
           eventsAddListener: jest.fn(),
           eventsNotifyReady: jest.fn(),
+          interstitialLoad: jest.fn(),
         },
         RNGoogleMobileAdsInterstitialModule: {},
         RNGoogleMobileAdsRewardedModule: {},

--- a/src/ads/MobileAd.ts
+++ b/src/ads/MobileAd.ts
@@ -99,6 +99,11 @@ export abstract class MobileAd implements MobileAdInterface {
       this._isLoadCalled = false;
     }
 
+    if (type === AdEventType.ERROR) {
+      this._loaded = false;
+      this._isLoadCalled = false;
+    }
+
     let payload: AdEventPayload<EventType> = data;
     if (error) {
       payload = NativeError.fromEvent(error, 'googleMobileAds');


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
If an ad fails to load its `_isLoadCalled` flag would still remain true causing further `load()` calls to do nothing. This prevented me from reloading interstitial and rewarded ads after they initally failed to load (eg. due to no-fill or network errors). This PR resets the `_isLoadCalled` flag if an ad failed to load with an error.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
- Fixes #195

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->
Allow load to be called again after an ad failed to load.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [x] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No
  - [x] Maybe? leaning towards no

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
Ran these changes in production using patch-package for a while. Also added unit tests, they pass.
:fire: ;)

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
