### PR TITLE
docs: fix broken link in the document

### DIFF
--- a/docs/displaying-ads.mdx
+++ b/docs/displaying-ads.mdx
@@ -82,10 +82,10 @@ const interstitial = InterstitialAd.createForAdRequest(adUnitId, {
 ```
 
 The second argument is additional optional request options object to be sent whilst loading an advert, such as keywords & location.
-Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](/reference/admob/requestoptions)
+Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/RequestOptions.ts#L18)
 documentation to view the full range of options available.
 
-The call to `createForAdRequest` returns an instance of the [`InterstitialAd`](/reference/admob/interstitialad) class,
+The call to `createForAdRequest` returns an instance of the [`InterstitialAd`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/ads/InterstitialAd.ts) class,
 which provides a number of utilities for loading and displaying interstitials.
 
 To listen to events, such as when the advert from the network has loaded or when an error occurs, we can subscribe via the
@@ -141,7 +141,7 @@ application.
 
 You can subscribe to other various events with `addAdEventListener` listener such as if the user clicks the advert,
 or closes the advert and returns back to your app. To view a full list of events which are available, view the
-[`AdEventType`](/reference/admob/adeventtype) documentation.
+[`AdEventType`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/AdEventType.ts#L18) documentation.
 
 If needed, you can reuse the existing instance of the `InterstitialAd` class to load more adverts and show them when required.
 
@@ -170,10 +170,10 @@ const rewarded = RewardedAd.createForAdRequest(adUnitId, {
 ```
 
 The second argument is additional optional request options object to be sent whilst loading an advert, such as keywords & location.
-Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](/reference/admob/requestoptions)
+Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/RequestOptions.ts#L18)
 documentation to view the full range of options available.
 
-The call to `createForAdRequest` returns an instance of the [`RewardedAd`](/reference/admob/rewardedad) class,
+The call to `createForAdRequest` returns an instance of the [`RewardedAd`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/RewardedAdReward.ts#L4) class,
 which provides a number of utilities for loading and displaying rewarded ads.
 
 To listen to events, such as when the advert from the network has loaded or when an error occurs, we can subscribe via the
@@ -240,13 +240,13 @@ Like Interstitial Ads, you can listen to the events with the `addAdEventListener
 the advert and returns back to your app. However, you can listen to an extra `EARNED_REWARD` event which is triggered when user completes the
 advert action. An additional `reward` payload is sent with the event, containing the amount and type of rewarded (specified via the dashboard).
 
-To learn more, view the [`RewardedAdEventType`](/reference/admob/rewardedadeventtype) documentation.
+To learn more, view the [`RewardedAdEventType`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/RewardedAdEventType.ts#L18) documentation.
 
 If needed, you can reuse the existing instance of the `RewardedAd` class to load more adverts and show them when required.
 
 While the `EARNED_REWARD` event only occurs on the client, Server Side Verification (or SSV) can be used for confirming a user completed an advert action. For this, you have to specify the Server Side Verification callback URL in your Ads dashboard.
 
-You can customize SSV parameters when your SSV callback is called by setting the `serverSideVerificationOptions` field in your [`RequestOptions`](/reference/admob/requestoptions) parameter.
+You can customize SSV parameters when your SSV callback is called by setting the `serverSideVerificationOptions` field in your [`RequestOptions`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/RequestOptions.ts#L18) parameter.
 
 ```js
 const rewardedAd = RewardedAd.createForAdRequest(adUnitId, {
@@ -292,10 +292,10 @@ const rewardedInterstitial = RewardedInterstitialAd.createForAdRequest(adUnitId,
 ```
 
 The second argument is additional optional request options object to be sent whilst loading an advert, such as keywords & location.
-Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](/reference/admob/requestoptions)
+Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/RequestOptions.ts#L18)
 documentation to view the full range of options available.
 
-The call to `createForAdRequest` returns an instance of the [`RewardedInterstitialAd`](/reference/admob/rewardedinterstitialad) class,
+The call to `createForAdRequest` returns an instance of the [`RewardedInterstitialAd`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/ads/RewardedInterstitialAd.ts) class,
 which provides a number of utilities for loading and displaying rewarded interstitial ads.
 
 To listen to events, such as when the advert from the network has loaded or when an error occurs, we can subscribe via the
@@ -371,13 +371,13 @@ Like Interstitial Ads, you can listen to the events with the `addAdEventListener
 the advert and returns back to your app. However, you can listen to an extra `EARNED_REWARD` event which is triggered when user completes the
 advert action. An additional `reward` payload is sent with the event, containing the amount and type of rewarded (specified via the dashboard).
 
-To learn more, view the [`RewardedAdEventType`](/reference/admob/rewardedadeventtype) documentation.
+To learn more, view the [`RewardedAdEventType`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/RewardedAdEventType.ts#L18) documentation.
 
 If needed, you can reuse the existing instance of the `RewardedInterstitialAd` class to load more adverts and show them when required.
 
 While the `EARNED_REWARD` event only occurs on the client, Server Side Verification (or SSV) can be used for confirming a user completed an advert action. For this, you have to specify the Server Side Verification callback URL in your Ads dashboard.
 
-You can customize SSV parameters when your SSV callback is called by setting the `serverSideVerificationOptions` field in your [`RequestOptions`](/reference/admob/requestoptions) parameter.
+You can customize SSV parameters when your SSV callback is called by setting the `serverSideVerificationOptions` field in your [`RequestOptions`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/RequestOptions.ts#L18) parameter.
 
 ```js
 const rewardedInterstitialAd = RewardedInterstitialAd.createForAdRequest(adUnitId, {
@@ -402,7 +402,7 @@ Banner ads are partial adverts which can be integrated within your existing appl
 a Banner only takes up a limited area of the application and displays an advert within the area. This allows you to integrate
 adverts without a disruptive action.
 
-The module exposes a [`BannerAd`](/reference/admob/bannerad) component. The `unitId` and `size` props are required to display
+The module exposes a [`BannerAd`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/BannerAdProps.ts) component. The `unitId` and `size` props are required to display
 a banner:
 
 ```js
@@ -424,13 +424,13 @@ function App() {
 }
 ```
 
-The `size` prop takes a [`BannerAdSize`](/reference/admob/banneradsize) type, and once the advert is available, will
+The `size` prop takes a [`BannerAdSize`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/BannerAdSize.ts#L19) type, and once the advert is available, will
 fill the space for the chosen size.
 
 > If no inventory for the size specified is available, an error will be thrown via `onAdFailedToLoad`!
 
 The `requestOptions` prop is additional optional request options object to be sent whilst loading an advert, such as keywords & location.
-Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](/reference/admob/requestoptions)
+Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/RequestOptions.ts#L18)
 documentation to view the full range of options available.
 
 The component also exposes props for listening to events, which you can use to handle the state of your app is the user
@@ -467,4 +467,4 @@ function App() {
 }
 ```
 
-The `sizes` prop takes an array of [`BannerAdSize`](/reference/admob/banneradsize) types.
+The `sizes` prop takes an array of [`BannerAdSize`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/BannerAdSize.ts#L19) types.


### PR DESCRIPTION
### Description

Some links of type reference in [the document](https://docs.page/invertase/react-native-google-mobile-ads/displaying-ads#banner-ads-component) are out of date and currently redirect to a 404 page.

e.g., [this page](https://docs.page/invertase/react-native-google-mobile-ads/reference/admob/adeventtype)

So, I modified it to a link to the type reference page.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

n/a

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

n/a

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
