### PR TITLE
fix(ios): correct typo in ios_config.sh

### DIFF
--- a/ios_config.sh
+++ b/ios_config.sh
@@ -126,7 +126,7 @@ for i in "${!_PLIST_ENTRY_KEYS[@]}"; do
 done
 
 if ! [[ -f "${_TARGET_PLIST}" ]]; then
-  echo "error: unable to locate Info.plist to set properties. App will crash without GADApplicationIdentier set."
+  echo "error: unable to locate Info.plist to set properties. App will crash without GADApplicationIdentifier set."
   exit 1
 fi
 


### PR DESCRIPTION
Tweak the ios_config.sh error to mention the `GADApplicationIdentifier` key from the Info.plist using the correct value - it may help with Ctrl-C troubleshooting.