### PR TITLE
Use activity instead of context for init

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.java
@@ -120,7 +120,7 @@ public class ReactNativeGoogleMobileAdsModule extends ReactNativeModule {
   @ReactMethod
   public void initialize(Promise promise) {
     MobileAds.initialize(
-        getApplicationContext(),
+        getCurrentActivity(),
         new OnInitializationCompleteListener() {
           @Override
           public void onInitializationComplete(InitializationStatus initializationStatus) {
@@ -157,7 +157,7 @@ public class ReactNativeGoogleMobileAdsModule extends ReactNativeModule {
         .runOnUiThread(
             () -> {
               MobileAds.openAdInspector(
-                  getApplicationContext(),
+                  getCurrentActivity(),
                   new OnAdInspectorClosedListener() {
                     @Override
                     public void onAdInspectorClosed(@Nullable AdInspectorError adInspectorError) {


### PR DESCRIPTION
This is required by some mediation partners (so far as I have found, partner: Ironsource).

Android only.
See error code 102: 
https://developers.google.com/admob/android/mediation/ironsource#step_4_additional_code_required