### PR TITLE
feat(ios, android): FLUID size support

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/LayoutWrapper.java
+++ b/android/src/main/java/io/invertase/googlemobileads/LayoutWrapper.java
@@ -6,6 +6,8 @@ import android.widget.FrameLayout;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.views.view.ReactViewGroup;
+import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.BaseAdView;
 
 public class LayoutWrapper extends FrameLayout {
@@ -22,33 +24,28 @@ public class LayoutWrapper extends FrameLayout {
   }
 
   private final Runnable measureAndLayout = () -> {
-    measure(
-      MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-      MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
-    layout(getLeft(), getTop(), getRight(), getBottom());
+
+    BaseAdView adView = getContentView();
+
+    if(adView != null) {
+      AdSize adSize = adView.getAdSize();
+      int left = adView.getLeft();
+      int top = adView.getTop();
+      int width = adSize.getWidthInPixels(getContext());
+      int height = adSize.getHeightInPixels(getContext());
+
+      measure(
+        MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+        MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY));
+      layout(left, top, left + width, top + height);
+    } else {
+      measure(
+        MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+        MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+      layout(getLeft(), getTop(), getRight(), getBottom());
+    }
   };
 
-  @Override
-  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-    int maxWidth = 0;
-    int maxHeight = 0;
-
-    for (int i = 0; i < getChildCount(); i++) {
-      View child = getChildAt(i);
-      if (child.getVisibility() != GONE) {
-        child.measure(widthMeasureSpec, MeasureSpec.UNSPECIFIED);
-
-        maxWidth = Math.max(maxWidth, child.getMeasuredWidth());
-        maxHeight = Math.max(maxHeight, child.getMeasuredHeight());
-      }
-    }
-
-    int finalWidth = Math.max(maxWidth, getSuggestedMinimumWidth());
-    int finalHeight = Math.max(maxHeight, getSuggestedMinimumHeight());
-
-    setMeasuredDimension(finalWidth, finalHeight);
-    ((ThemedReactContext) getContext()).runOnNativeModulesQueueThread(() -> ((ThemedReactContext) getContext()).getNativeModule(UIManagerModule.class).updateNodeSize(getId(), finalWidth, finalHeight));
-  }
 
   public void setContentView(BaseAdView view) {
     contentView = view;

--- a/android/src/main/java/io/invertase/googlemobileads/LayoutWrapper.java
+++ b/android/src/main/java/io/invertase/googlemobileads/LayoutWrapper.java
@@ -1,0 +1,62 @@
+package io.invertase.googlemobileads;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.google.android.gms.ads.BaseAdView;
+
+public class LayoutWrapper extends FrameLayout {
+  private BaseAdView contentView;
+
+  public LayoutWrapper(Context context) {
+    super(context);
+  }
+
+  @Override
+  public void requestLayout() {
+    super.requestLayout();
+    post(measureAndLayout);
+  }
+
+  private final Runnable measureAndLayout = () -> {
+    measure(
+      MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+      MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+    layout(getLeft(), getTop(), getRight(), getBottom());
+  };
+
+  @Override
+  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    int maxWidth = 0;
+    int maxHeight = 0;
+
+    for (int i = 0; i < getChildCount(); i++) {
+      View child = getChildAt(i);
+      if (child.getVisibility() != GONE) {
+        child.measure(widthMeasureSpec, MeasureSpec.UNSPECIFIED);
+
+        maxWidth = Math.max(maxWidth, child.getMeasuredWidth());
+        maxHeight = Math.max(maxHeight, child.getMeasuredHeight());
+      }
+    }
+
+    int finalWidth = Math.max(maxWidth, getSuggestedMinimumWidth());
+    int finalHeight = Math.max(maxHeight, getSuggestedMinimumHeight());
+
+    setMeasuredDimension(finalWidth, finalHeight);
+    ((ThemedReactContext) getContext()).runOnNativeModulesQueueThread(() -> ((ThemedReactContext) getContext()).getNativeModule(UIManagerModule.class).updateNodeSize(getId(), finalWidth, finalHeight));
+  }
+
+  public void setContentView(BaseAdView view) {
+    contentView = view;
+    addView(contentView);
+  }
+
+  public BaseAdView getContentView() {
+    return contentView;
+  }
+
+}

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -126,7 +126,7 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
       }
     }
 
-    if (sizeList.size() > 0 && !isFluid) {
+    if (sizeList.size() > 0 && !sizeList.contains(AdSize.FLUID)) {
       AdSize adSize = sizeList.get(0);
       WritableMap payload = Arguments.createMap();
       payload.putDouble("width", adSize.getWidth());
@@ -170,9 +170,9 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
       new AdListener() {
         @Override
         public void onAdLoaded() {
-          if(isFluid) return;
+          reactViewGroup.requestLayout();
 
-          adView.requestLayout();
+          if(isFluid) return;
 
           AdSize adSize = adView.getAdSize();
           WritableMap payload = Arguments.createMap();

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -172,6 +172,8 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
         public void onAdLoaded() {
           if(isFluid) return;
 
+          adView.requestLayout();
+
           AdSize adSize = adView.getAdSize();
           WritableMap payload = Arguments.createMap();
           payload.putDouble("width", adSize.getWidth());

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
 
 public class ReactNativeGoogleMobileAdsCommon {
 
-  static AdSize getAdSizeForAdaptiveBanner(String preDefinedAdSize, ReactViewGroup reactViewGroup) {
+  static AdSize getAdSizeForAdaptiveBanner(String preDefinedAdSize, LayoutWrapper reactViewGroup) {
 
     try {
       Display display =
@@ -63,7 +63,7 @@ public class ReactNativeGoogleMobileAdsCommon {
     }
   }
 
-  static AdSize getAdSize(String preDefinedAdSize, ReactViewGroup reactViewGroup) {
+  static AdSize getAdSize(String preDefinedAdSize, LayoutWrapper reactViewGroup) {
     if (preDefinedAdSize.matches(
         "ADAPTIVE_BANNER|ANCHORED_ADAPTIVE_BANNER|INLINE_ADAPTIVE_BANNER")) {
       return ReactNativeGoogleMobileAdsCommon.getAdSizeForAdaptiveBanner(

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.m
@@ -33,6 +33,7 @@
 @property(nonatomic, copy) NSString *unitId;
 @property(nonatomic, copy) NSDictionary *request;
 @property(nonatomic, copy) NSNumber *manualImpressionsEnabled;
+@property(nonatomic, copy) NSNumber *fluidWidth;
 @property(nonatomic, assign) BOOL propsChanged;
 
 @property(nonatomic, copy) RCTBubblingEventBlock onNativeEvent;
@@ -56,6 +57,13 @@
   }
   if ([RNGoogleMobileAdsCommon isAdManagerUnit:_unitId]) {
     _banner = [[GAMBannerView alloc] initWithAdSize:adSize];
+
+    
+    if(GADAdSizeEqualToSize(adSize,GADAdSizeFluid)) {
+      CGRect frameRect = _banner.frame;
+      frameRect.size.width = [_fluidWidth integerValue];
+      _banner.frame = frameRect;
+    }
 
     ((GAMBannerView *)_banner).validAdSizes = _sizes;
     ((GAMBannerView *)_banner).appEventDelegate = self;
@@ -188,6 +196,8 @@ RCT_EXPORT_VIEW_PROPERTY(unitId, NSString);
 RCT_EXPORT_VIEW_PROPERTY(request, NSDictionary);
 
 RCT_EXPORT_VIEW_PROPERTY(manualImpressionsEnabled, BOOL);
+
+RCT_EXPORT_VIEW_PROPERTY(fluidWidth, NSNumber);
 
 RCT_EXPORT_VIEW_PROPERTY(onNativeEvent, RCTBubblingEventBlock);
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.m
@@ -33,7 +33,6 @@
 @property(nonatomic, copy) NSString *unitId;
 @property(nonatomic, copy) NSDictionary *request;
 @property(nonatomic, copy) NSNumber *manualImpressionsEnabled;
-@property(nonatomic, copy) NSNumber *fluidWidth;
 @property(nonatomic, assign) BOOL propsChanged;
 
 @property(nonatomic, copy) RCTBubblingEventBlock onNativeEvent;
@@ -60,9 +59,8 @@
 
     
     if(GADAdSizeEqualToSize(adSize,GADAdSizeFluid)) {
-      CGRect frameRect = _banner.frame;
-      frameRect.size.width = [_fluidWidth integerValue];
-      _banner.frame = frameRect;
+      _banner.frame = self.bounds;
+      _banner.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
     }
 
     ((GAMBannerView *)_banner).validAdSizes = _sizes;
@@ -196,8 +194,6 @@ RCT_EXPORT_VIEW_PROPERTY(unitId, NSString);
 RCT_EXPORT_VIEW_PROPERTY(request, NSDictionary);
 
 RCT_EXPORT_VIEW_PROPERTY(manualImpressionsEnabled, BOOL);
-
-RCT_EXPORT_VIEW_PROPERTY(fluidWidth, NSNumber);
 
 RCT_EXPORT_VIEW_PROPERTY(onNativeEvent, RCTBubblingEventBlock);
 

--- a/src/ads/BaseAd.tsx
+++ b/src/ads/BaseAd.tsx
@@ -123,7 +123,7 @@ export const BaseAd = React.forwardRef<GoogleMobileAdsBannerView, GAMBannerAdPro
           height: dimensions[1],
         };
 
-    const fluidWidth = sizes.includes(BannerAdSize.FLUID) ? width : null;
+    const fluidWidth = sizes.includes(BannerAdSize.FLUID) ? width : undefined;
 
     return (
       <GoogleMobileAdsBannerView

--- a/src/ads/BaseAd.tsx
+++ b/src/ads/BaseAd.tsx
@@ -46,7 +46,7 @@ type NativeEvent =
 const sizeRegex = /([0-9]+)x([0-9]+)/;
 
 export const BaseAd = React.forwardRef<GoogleMobileAdsBannerView, GAMBannerAdProps>(
-  ({ unitId, sizes, requestOptions, manualImpressionsEnabled, width, ...props }, ref) => {
+  ({ unitId, sizes, requestOptions, manualImpressionsEnabled, ...props }, ref) => {
     const [dimensions, setDimensions] = useState<(number | string)[]>([0, 0]);
 
     useEffect(() => {
@@ -123,8 +123,6 @@ export const BaseAd = React.forwardRef<GoogleMobileAdsBannerView, GAMBannerAdPro
           height: dimensions[1],
         };
 
-    const fluidWidth = sizes.includes(BannerAdSize.FLUID) ? width : undefined;
-
     return (
       <GoogleMobileAdsBannerView
         ref={ref}
@@ -134,7 +132,6 @@ export const BaseAd = React.forwardRef<GoogleMobileAdsBannerView, GAMBannerAdPro
         request={validateAdRequestOptions(requestOptions)}
         manualImpressionsEnabled={!!manualImpressionsEnabled}
         onNativeEvent={onNativeEvent}
-        fluidWidth={fluidWidth}
       />
     );
   },
@@ -150,7 +147,6 @@ interface NativeBannerProps {
   unitId: string;
   request: RequestOptions;
   manualImpressionsEnabled: boolean;
-  fluidWidth?: number;
   onNativeEvent: (event: { nativeEvent: NativeEvent }) => void;
 }
 

--- a/src/ads/BaseAd.tsx
+++ b/src/ads/BaseAd.tsx
@@ -115,8 +115,7 @@ export const BaseAd = React.forwardRef<GoogleMobileAdsBannerView, GAMBannerAdPro
 
     const style = sizes.includes(BannerAdSize.FLUID)
       ? {
-          width: '100%',
-          height: dimensions[1],
+          flex: 1
         }
       : {
           width: dimensions[0],

--- a/src/ads/BaseAd.tsx
+++ b/src/ads/BaseAd.tsx
@@ -46,7 +46,7 @@ type NativeEvent =
 const sizeRegex = /([0-9]+)x([0-9]+)/;
 
 export const BaseAd = React.forwardRef<GoogleMobileAdsBannerView, GAMBannerAdProps>(
-  ({ unitId, sizes, requestOptions, manualImpressionsEnabled, ...props }, ref) => {
+  ({ unitId, sizes, requestOptions, manualImpressionsEnabled, width, ...props }, ref) => {
     const [dimensions, setDimensions] = useState<(number | string)[]>([0, 0]);
 
     useEffect(() => {
@@ -123,6 +123,8 @@ export const BaseAd = React.forwardRef<GoogleMobileAdsBannerView, GAMBannerAdPro
           height: dimensions[1],
         };
 
+    const fluidWidth = sizes.includes(BannerAdSize.FLUID) ? width : null;
+
     return (
       <GoogleMobileAdsBannerView
         ref={ref}
@@ -132,6 +134,7 @@ export const BaseAd = React.forwardRef<GoogleMobileAdsBannerView, GAMBannerAdPro
         request={validateAdRequestOptions(requestOptions)}
         manualImpressionsEnabled={!!manualImpressionsEnabled}
         onNativeEvent={onNativeEvent}
+        fluidWidth={fluidWidth}
       />
     );
   },
@@ -147,6 +150,7 @@ interface NativeBannerProps {
   unitId: string;
   request: RequestOptions;
   manualImpressionsEnabled: boolean;
+  fluidWidth?: number;
   onNativeEvent: (event: { nativeEvent: NativeEvent }) => void;
 }
 

--- a/src/types/BannerAdProps.ts
+++ b/src/types/BannerAdProps.ts
@@ -143,12 +143,6 @@ export interface GAMBannerAdProps extends Omit<BannerAdProps, 'size'> {
    */
   manualImpressionsEnabled?: boolean;
 
-  /*
-   *
-   Only applicable for FLUID ads. Sets the width of the ad
-  * */
-  width?: number;
-
   /**
    * When an ad received Ad Manager specific app events.
    */

--- a/src/types/BannerAdProps.ts
+++ b/src/types/BannerAdProps.ts
@@ -143,6 +143,12 @@ export interface GAMBannerAdProps extends Omit<BannerAdProps, 'size'> {
    */
   manualImpressionsEnabled?: boolean;
 
+  /*
+   *
+   Only applicable for FLUID ads. Sets the width of the ad
+  * */
+  width?: number;
+
   /**
    * When an ad received Ad Manager specific app events.
    */


### PR DESCRIPTION
### Description

Support for FLUID size on Android and fix for iOS FLUID size.

Android: FLUID size wasn't supported yet on Android. Fixes #120 
iOS: FLUID size was taking full device width. Fixes #213 

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

---
Tested on various sizes including FLUID on Android and iOS, with different media (video/poll/creatives).

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
