### PR TITLE
docs(hooks):  fix typo throwed to thrown in displaying-ads-hook.md

### DIFF
--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -88,7 +88,7 @@ Return values of the hook are:
 | isOpened       | boolean                            | Whether the ad is opened. The value is remained `true` even after the ad is closed unless **new ad is requested**. |
 | isClosed       | boolean                            | Whether your ad is dismissed.                                                                                      |
 | isShowing      | boolean                            | Whether your ad is showing. The value is equal with `isOpened && !isClosed`.                                       |
-| error          | Error \| undefined                 | `Error` object throwed during ad load.                                                                             |
+| error          | Error \| undefined                 | `Error` object thrown during ad load.                                                                             |
 | reward         | [RewardedAdReward](#) \| undefined | Loaded reward item of the Rewarded Ad. Available only in RewardedAd.                                               |
 | isEarnedReward | boolean                            | Whether the user earned the reward by Rewarded Ad.                                                                 |
 | load           | Function                           | Start loading the advert with the provided RequestOptions.                                                         |


### PR DESCRIPTION
### Description

"thrown" is the correct past tense form of "throw"

### Related issues

None

### Release Summary

Fix past tense version of throw in docs

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests; **N/A**
  - [x] `e2e` tests added or updated in `__tests__e2e__`
  - [x] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change. **N/A**
- This is a breaking change;
  - [x] Yes
  - [x] No

### Test Plan

No need for tests

---
