### PR TITLE
feat: inline adaptive banner with custom width

### DIFF
--- a/RNGoogleMobileAdsExample/App.tsx
+++ b/RNGoogleMobileAdsExample/App.tsx
@@ -174,14 +174,16 @@ class InterstitialTest implements Test {
 }
 
 class BannerTest implements Test {
-  bannerAdSize: BannerAdSize | string;
+  bannerAdSize: BannerAdSize | `${number}x${number | ''}`;
+  path?: string;
 
-  constructor(bannerAdSize) {
+  constructor(bannerAdSize, path?: string) {
     this.bannerAdSize = bannerAdSize;
+    this.path = path;
   }
 
   getPath(): string {
-    return this.bannerAdSize;
+    return this.path || this.bannerAdSize;
   }
 
   getTestType(): TestType {
@@ -853,6 +855,10 @@ class GAMInterstitialTest implements Test {
 Object.keys(BannerAdSize).forEach(bannerAdSize => {
   TestRegistry.registerTest(new BannerTest(bannerAdSize));
 });
+TestRegistry.registerTest(new BannerTest('300x200', 'Banner (Custom Size)'));
+TestRegistry.registerTest(
+  new BannerTest('300x', 'Inline Adaptive Banner (Custom Width)'),
+);
 TestRegistry.registerTest(new AppOpenTest());
 TestRegistry.registerTest(new InterstitialTest());
 TestRegistry.registerTest(new RewardedTest());

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
@@ -69,17 +69,21 @@ public class ReactNativeGoogleMobileAdsCommon {
       return ReactNativeGoogleMobileAdsCommon.getAdSizeForAdaptiveBanner(
           preDefinedAdSize, reactViewGroup);
     } else {
-      return ReactNativeGoogleMobileAdsCommon.stringToAdSize(preDefinedAdSize);
+      return ReactNativeGoogleMobileAdsCommon.stringToAdSize(preDefinedAdSize, reactViewGroup);
     }
   }
 
-  static AdSize stringToAdSize(String value) {
-    Pattern pattern = Pattern.compile("([0-9]+)x([0-9]+)");
+  static AdSize stringToAdSize(String value, ReactViewGroup reactViewGroup) {
+    Pattern pattern = Pattern.compile("([0-9]+)x([0-9]+|)");
     Matcher matcher = pattern.matcher(value);
 
     // If size is "valXval"
     if (matcher.find()) {
       int width = Integer.parseInt(matcher.group(1));
+      if (matcher.group(2).isEmpty()) {
+        return AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(
+            reactViewGroup.getContext(), width);
+      }
       int height = Integer.parseInt(matcher.group(2));
       return new AdSize(width, height);
     }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.m
@@ -163,7 +163,7 @@ NSString *const GOOGLE_MOBILE_ADS_EVENT_REWARDED_EARNED_REWARD = @"rewarded_earn
 + (GADAdSize)stringToAdSize:(NSString *)value {
   NSError *error = nil;
   NSRegularExpression *regex =
-      [NSRegularExpression regularExpressionWithPattern:@"([0-9]+)x([0-9]+)"
+      [NSRegularExpression regularExpressionWithPattern:@"([0-9]+)x([0-9]+|)"
                                                 options:0
                                                   error:&error];
   NSArray *matches = [regex matchesInString:value options:0 range:NSMakeRange(0, [value length])];
@@ -173,8 +173,12 @@ NSString *const GOOGLE_MOBILE_ADS_EVENT_REWARDED_EARNED_REWARD = @"rewarded_earn
     if (matchText) {
       NSArray *values = [matchText componentsSeparatedByString:@"x"];
       CGFloat width = (CGFloat)[values[0] intValue];
-      CGFloat height = (CGFloat)[values[1] intValue];
-      return GADAdSizeFromCGSize(CGSizeMake(width, height));
+      if ([values[1] isEqualToString:@""]) {
+        return GADCurrentOrientationInlineAdaptiveBannerAdSizeWithWidth(width);
+      } else {
+        CGFloat height = (CGFloat)[values[1] intValue];
+        return GADAdSizeFromCGSize(CGSizeMake(width, height));
+      }
     }
   }
 

--- a/src/ads/BaseAd.tsx
+++ b/src/ads/BaseAd.tsx
@@ -43,7 +43,7 @@ type NativeEvent =
       data?: string;
     };
 
-const sizeRegex = /([0-9]+)x([0-9]+)/;
+const sizeRegex = /([0-9]+)x([0-9]+|)/;
 
 export const BaseAd = React.forwardRef<GoogleMobileAdsBannerView, GAMBannerAdProps>(
   ({ unitId, sizes, requestOptions, manualImpressionsEnabled, ...props }, ref) => {

--- a/src/types/BannerAdProps.ts
+++ b/src/types/BannerAdProps.ts
@@ -41,11 +41,11 @@ export interface BannerAdProps {
   unitId: string;
 
   /**
-   * The size of the banner. Can be a predefined size via `BannerAdSize` or custom dimensions, e.g. `300x200`.
+   * The size of the banner. Can be a predefined size via `BannerAdSize` or custom dimensions (WxH), e.g. `300x200` or `300x` for adaptive height.
    *
    * Inventory must be available for the banner size specified, otherwise a no-fill error will be sent to `onAdFailedToLoad`.
    */
-  size: BannerAdSize | string;
+  size: BannerAdSize | `${number}x${number | ''}`;
 
   /**
    * The request options for this banner.


### PR DESCRIPTION
### Description

Currently an adaptive banner always takes the screen width (with taking into account safe areas).
There are multiple users that would like to use a custom width and seem to fall back to trying out "FLUID" sizing?
Currently you can define a custom size "300x200" to get a custom sized ad. This PR makes it possible get an ad with custom width + adaptive height.

### Usage
`<Banner size="300x" unitId="***" /> `
``<Banner size={`${SCREEN_WIDTH - MARGIN}x`} unitId="***" /> ``
