### PR TITLE
feat(debug): add debug module

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsDebugModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsDebugModule.java
@@ -1,0 +1,34 @@
+package io.invertase.googlemobileads;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactMethod;
+import com.google.android.gms.ads.MobileAds;
+
+import io.invertase.googlemobileads.common.ReactNativeModule;
+
+class ReactNativeGoogleMobileAdsDebugModule extends ReactNativeModule {
+  public static final String SERVICE = "RNGoogleMobileAdsDebugModule";
+
+  public ReactNativeGoogleMobileAdsDebugModule(ReactApplicationContext reactContext) {
+    super(reactContext, SERVICE);
+  }
+
+  @ReactMethod
+  public void openDebugMenu(final String adUnit) {
+    new Handler(Looper.getMainLooper()).post(new Runnable() {
+      @Override
+      public void run () {
+        try {
+          MobileAds.initialize(getReactApplicationContext());
+          MobileAds.openDebugMenu(getActivity(), adUnit);
+        } catch (Exception e) {
+          Log.e(this.getClass().getName(), "openDebugMenu Failed", e);
+        }
+      }
+    });
+  }
+}

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsDebugModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsDebugModule.java
@@ -3,11 +3,9 @@ package io.invertase.googlemobileads;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
-
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.google.android.gms.ads.MobileAds;
-
 import io.invertase.googlemobileads.common.ReactNativeModule;
 
 class ReactNativeGoogleMobileAdsDebugModule extends ReactNativeModule {
@@ -19,16 +17,18 @@ class ReactNativeGoogleMobileAdsDebugModule extends ReactNativeModule {
 
   @ReactMethod
   public void openDebugMenu(final String adUnit) {
-    new Handler(Looper.getMainLooper()).post(new Runnable() {
-      @Override
-      public void run () {
-        try {
-          MobileAds.initialize(getReactApplicationContext());
-          MobileAds.openDebugMenu(getActivity(), adUnit);
-        } catch (Exception e) {
-          Log.e(this.getClass().getName(), "openDebugMenu Failed", e);
-        }
-      }
-    });
+    new Handler(Looper.getMainLooper())
+        .post(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  MobileAds.initialize(getReactApplicationContext());
+                  MobileAds.openDebugMenu(getActivity(), adUnit);
+                } catch (Exception e) {
+                  Log.e(this.getClass().getName(), "openDebugMenu Failed", e);
+                }
+              }
+            });
   }
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsDebugModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsDebugModule.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <React/RCTBridgeModule.h>
+
+@interface RNGoogleMobileAdsDebugModule : NSObject <RCTBridgeModule>
+
+@end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsDebugModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsDebugModule.m
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import <GoogleMobileAds/GoogleMobileAds.h>
+#import <React/RCTUtils.h>
+
+#import "RNGoogleMobileAdsDebugModule.h"
+
+@implementation RNGoogleMobileAdsDebugModule
+#pragma mark -
+#pragma mark Module Setup
+
+RCT_EXPORT_MODULE();
+
+- (dispatch_queue_t)methodQueue {
+  return dispatch_get_main_queue();
+}
+
+#pragma mark -
+#pragma mark Google Mobile Ads Methods
+
+RCT_EXPORT_METHOD(openDebugMenu : (NSString *)adUnitID) {
+    GADDebugOptionsViewController *debugOptionsViewController = [GADDebugOptionsViewController debugOptionsViewControllerWithAdUnitID:adUnitID];
+    
+    [[UIApplication sharedApplication].delegate.window.rootViewController
+     presentViewController:debugOptionsViewController
+     animated:YES
+     completion:nil];
+}
+
+@end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsDebugModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsDebugModule.m
@@ -34,12 +34,13 @@ RCT_EXPORT_MODULE();
 #pragma mark Google Mobile Ads Methods
 
 RCT_EXPORT_METHOD(openDebugMenu : (NSString *)adUnitID) {
-    GADDebugOptionsViewController *debugOptionsViewController = [GADDebugOptionsViewController debugOptionsViewControllerWithAdUnitID:adUnitID];
-    
-    [[UIApplication sharedApplication].delegate.window.rootViewController
-     presentViewController:debugOptionsViewController
-     animated:YES
-     completion:nil];
+  GADDebugOptionsViewController *debugOptionsViewController =
+      [GADDebugOptionsViewController debugOptionsViewControllerWithAdUnitID:adUnitID];
+
+  [[UIApplication sharedApplication].delegate.window.rootViewController
+      presentViewController:debugOptionsViewController
+                   animated:YES
+                 completion:nil];
 }
 
 @end

--- a/src/Debug.ts
+++ b/src/Debug.ts
@@ -1,0 +1,9 @@
+import { NativeModules } from 'react-native';
+
+const RNGoogleMobileAdsDebugModule = NativeModules.RNGoogleMobileAdsDebugModule;
+
+export const Debug = {
+  openDebugMenu(adUnit: string) {
+    RNGoogleMobileAdsDebugModule.openDebugMenu(adUnit);
+  },
+};

--- a/src/Debug.ts
+++ b/src/Debug.ts
@@ -1,8 +1,9 @@
 import { NativeModules } from 'react-native';
+import { DebugInterface } from './types/Debug.interface';
 
 const RNGoogleMobileAdsDebugModule = NativeModules.RNGoogleMobileAdsDebugModule;
 
-export const Debug = {
+export const Debug: DebugInterface = {
   openDebugMenu(adUnit: string) {
     RNGoogleMobileAdsDebugModule.openDebugMenu(adUnit);
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,4 +43,5 @@ export { useAppOpenAd } from './hooks/useAppOpenAd';
 export { useInterstitialAd } from './hooks/useInterstitialAd';
 export { useRewardedAd } from './hooks/useRewardedAd';
 export { useRewardedInterstitialAd } from './hooks/useRewardedInterstitialAd';
+export { Debug } from './Debug';
 export * from './types';

--- a/src/types/Debug.interface.ts
+++ b/src/types/Debug.interface.ts
@@ -2,9 +2,9 @@
  * Method to open the Native Ad SDK's debug menu
  */
 export interface DebugInterface {
-    /**
-     * Opens the Ad debug menu
-     * @param adUnit The Ad Unit ID
-     */
-    openDebugMenu: (adUnit: string) => void
+  /**
+   * Opens the Ad debug menu
+   * @param adUnit The Ad Unit ID
+   */
+  openDebugMenu: (adUnit: string) => void;
 }

--- a/src/types/Debug.interface.ts
+++ b/src/types/Debug.interface.ts
@@ -1,0 +1,3 @@
+export interface DebugInterface {
+    openDebugMenu: (adUnit:string)=>void
+}

--- a/src/types/Debug.interface.ts
+++ b/src/types/Debug.interface.ts
@@ -1,3 +1,10 @@
+/**
+ * Method to open the Native Ad SDK's debug menu
+ */
 export interface DebugInterface {
-    openDebugMenu: (adUnit:string)=>void
+    /**
+     * Opens the Ad debug menu
+     * @param adUnit The Ad Unit ID
+     */
+    openDebugMenu: (adUnit: string) => void
 }


### PR DESCRIPTION
### Description

Our in-house ad team need access to the Google Mobile Ads Debug Menu.

This PR is to have access to a `NativeModule` method to trigger the required Ad SDK method.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Render a button that onPress will call the Native Module's method with the ad's `unitId`

```ts
import { Debug } from 'react-native-google-mobile-ads'

…
Debug.openDebugMenu(props.adUnitID)
…

```

---

:fire:
