### PR TITLE
fix(type): fixed  mobileAds initialize response status type

### DIFF
--- a/src/types/AdapterStatus.ts
+++ b/src/types/AdapterStatus.ts
@@ -16,5 +16,5 @@ export enum InitializationState {
 export type AdapterStatus = {
   name: string;
   description: string;
-  status: InitializationState;
+  state: InitializationState;
 };


### PR DESCRIPTION
### Description

As described in the documentation, this will be under the initialization process.

```ts
mport mobileAds from 'react-native-google-mobile-ads';

mobileAds()
  .initialize()
  .then(adapterStatuses => {
    // Initialization complete!
  });
```

The actual values returned during initialization can be seen in the console as follows.

```zsh
{"adapterStatuses":
  [
    {
      "description": "<GADAdapterStatus: 0x283ad8ec0;state = Ready>",
      "name": "GADMobileAds",
      "state": 1
    }
  ]
}
```

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
