### PR TITLE
fix(banner, ios): Fix not able to receive banner app event on iOS

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.m
@@ -159,8 +159,8 @@
   [self sendEvent:@"onAdClosed" payload:nil];
 }
 
-- (void)bannerView:(GAMBannerView *)bannerView
-    didReceiveAppEvent:(NSString *)name
+- (void)adView:(nonnull GADBannerView *)banner
+    didReceiveAppEvent:(nonnull NSString *)name
               withInfo:(nullable NSString *)info {
   [self sendEvent:@"onAppEvent"
           payload:@{


### PR DESCRIPTION
### Description

I was not able to receive any AppEvent fired from the ads on iOS while it worked fine on Android.

After some digging, it turns out that `RNGoogleMobileAdsBannerViewManager` used an incorrect method signature:
https://developers.google.com/admob/ios/api/reference/Protocols/GADAppEventDelegate

it should be `[-adView:didReceiveAppEvent:withInfo:]` intead of `[-bannerView:didReceiveAppEvent:withInfo:]`

### Related issues

N/A

### Release Summary

- Fix not being able to receive banner app event on iOS

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Verified on iOS 16 that the native code is now able to receive app events fired from ads html
Test AdUnits from Google iOS SDK Example:  `/6499/example/APIDemo/AppEvents`

https://developers.google.com/ad-manager/mobile-ads-sdk/ios/banner#app_events
---

