### PR TITLE
feat(ios, android): banner full width

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -135,6 +135,12 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
     reactViewGroup.setPropsChanged(true);
   }
 
+  @ReactProp(name = "fullWidthEnabled")
+  public void setFullWidthEnabled(ReactNativeAdView reactViewGroup, Boolean value) {
+    reactViewGroup.setFullWidthEnabled(value);
+    reactViewGroup.setPropsChanged(true);
+  }
+
   @Override
   public void onAfterUpdateTransaction(@NonNull ReactNativeAdView reactViewGroup) {
     super.onAfterUpdateTransaction(reactViewGroup);
@@ -174,6 +180,11 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
               width = reactViewGroup.getWidth();
               height = reactViewGroup.getHeight();
             } else {
+              if (Boolean.TRUE.equals(reactViewGroup.getFullWidthEnabled())
+                  && adView instanceof AdManagerAdView) {
+                adSize = new AdSize(AdSize.FULL_WIDTH, adSize.getHeight());
+                ((AdManagerAdView) adView).setAdSizes(adSize);
+              }
               left = adView.getLeft();
               top = adView.getTop();
               width = adSize.getWidthInPixels(reactViewGroup.getContext());

--- a/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeAdView.java
+++ b/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeAdView.java
@@ -13,6 +13,7 @@ public class ReactNativeAdView extends ReactViewGroup {
   private boolean manualImpressionsEnabled;
   private boolean propsChanged;
   private boolean isFluid;
+  private boolean fullWidthEnabled;
 
   public ReactNativeAdView(final Context context) {
     super(context);
@@ -64,5 +65,13 @@ public class ReactNativeAdView extends ReactViewGroup {
 
   public boolean getIsFluid() {
     return this.isFluid;
+  }
+
+  public void setFullWidthEnabled(boolean fullWidthEnabled) {
+    this.fullWidthEnabled = fullWidthEnabled;
+  }
+
+  public boolean getFullWidthEnabled() {
+    return this.fullWidthEnabled;
   }
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.h
@@ -30,6 +30,7 @@
 @property(nonatomic, copy) NSDictionary *request;
 @property(nonatomic, copy) NSNumber *manualImpressionsEnabled;
 @property(nonatomic, assign) BOOL propsChanged;
+@property(nonatomic, assign) BOOL fullWidthEnabled;
 
 @property(nonatomic, copy) RCTBubblingEventBlock onNativeEvent;
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.m
@@ -74,6 +74,11 @@
   _propsChanged = true;
 }
 
+- (void)setFullWidthEnabled:(BOOL)fullWidthEnabled {
+  _fullWidthEnabled = fullWidthEnabled;
+  _propsChanged = true;
+}
+
 - (void)requestAd {
 #ifndef __LP64__
   return;  // prevent crash on 32bit
@@ -113,10 +118,17 @@
 }
 
 - (void)bannerViewDidReceiveAd:(GADBannerView *)bannerView {
+  GADAdSize adSize = bannerView.adSize;
+
+  if (_fullWidthEnabled) {
+    adSize.size.width = CGRectGetWidth([[UIScreen mainScreen] bounds]);
+    [((GAMBannerView *)bannerView) resize:adSize];
+  }
+
   [self sendEvent:@"onAdLoaded"
           payload:@{
-            @"width" : @(bannerView.bounds.size.width),
-            @"height" : @(bannerView.bounds.size.height),
+            @"width" : @(adSize.size.width),
+            @"height" : @(adSize.size.height),
           }];
 }
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.m
@@ -32,6 +32,8 @@ RCT_EXPORT_VIEW_PROPERTY(request, NSDictionary);
 
 RCT_EXPORT_VIEW_PROPERTY(manualImpressionsEnabled, BOOL);
 
+RCT_EXPORT_VIEW_PROPERTY(fullWidthEnabled, BOOL);
+
 RCT_EXPORT_VIEW_PROPERTY(onNativeEvent, RCTBubblingEventBlock);
 
 RCT_EXPORT_METHOD(recordManualImpression : (nonnull NSNumber *)reactTag) {

--- a/src/ads/BaseAd.tsx
+++ b/src/ads/BaseAd.tsx
@@ -134,6 +134,7 @@ export const BaseAd = React.forwardRef<GoogleMobileAdsBannerView, GAMBannerAdPro
         request={validateAdRequestOptions(requestOptions)}
         manualImpressionsEnabled={!!manualImpressionsEnabled}
         onNativeEvent={onNativeEvent}
+        fullWidthEnabled={props.fullWidthEnabled}
       />
     );
   },
@@ -150,6 +151,7 @@ interface NativeBannerProps {
   request: RequestOptions;
   manualImpressionsEnabled: boolean;
   onNativeEvent: (event: { nativeEvent: NativeEvent }) => void;
+  fullWidthEnabled?: boolean;
 }
 
 const GoogleMobileAdsBannerView = requireNativeComponent<NativeBannerProps>(

--- a/src/types/BannerAdProps.ts
+++ b/src/types/BannerAdProps.ts
@@ -147,4 +147,20 @@ export interface GAMBannerAdProps extends Omit<BannerAdProps, 'size'> {
    * When an ad received Ad Manager specific app events.
    */
   onAppEvent?: (appEvent: AppEvent) => void;
+
+  /**
+   * If enabled, the received ad's width will be resized using the following approaches:
+   * Android:
+   * ```java
+   * adSize = new AdSize(AdSize.FULL_WIDTH, adSize.getHeight());
+   * ((AdManagerAdView) adView).setAdSizes(adSize);
+   * ```
+   *
+   * iOS:
+   * ```objective-c
+   * adSize.size.width = CGRectGetWidth([[UIScreen mainScreen] bounds]);
+   * [((GAMBannerView *)bannerView) resize: adSize];
+   * ```
+   */
+  fullWidthEnabled?: boolean;
 }


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
This PR adds the ability for an ad slot to resize to the full width of the screen. On Android this prop only applies to the `AdManagerAdView`.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

// TODO:

---

🔥 
