### PR TITLE
docs(ios): add advice on requesting app tracking transparency

### DIFF
--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -28,6 +28,7 @@ To setup and configure ads consent collection, first of all:
   -keep class com.google.android.gms.internal.consent_sdk.** { *; }
   ```
 - For Expo users, add extraProguardRules property to `app.json` file following this guide [Expo](https://docs.expo.dev/versions/latest/sdk/build-properties/#pluginconfigtypeandroid):
+
 ```json
 {
   "expo": {
@@ -37,15 +38,15 @@ To setup and configure ads consent collection, first of all:
         {
           "android": {
             "extraProguardRules": "-keep class com.google.android.gms.internal.consent_sdk.** { *; }"
-          },
+          }
         }
       ]
     ]
   }
 }
 ```
-You'll need to generate a new development build before using it.
 
+You'll need to generate a new development build before using it.
 
 ### Delaying app measurement
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -169,6 +169,37 @@ mobileAds()
 
 If you are using mediation, you may wish to wait until the promise is settled before loading ads, as this will ensure that all mediation adapters are initialized.
 
+### App Tracking Transparency (iOS)
+
+Apple requires apps to display the App Tracking Transparency authorization request for accessing the IDFA (leaving the choice to the user, whether to use personalized or non-personalized ads).
+Within your projects `app.json` file, you have to use the `user_tracking_usage_description` to describe your usage:
+
+```json
+{
+  "react-native-google-mobile-ads": {
+    "android_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
+    "ios_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
+    "user_tracking_usage_description": "This identifier will be used to deliver personalized ads to you."
+  }
+}
+```
+
+To request the App Tracking Transparency authorization we recommend using the [react-native-permissions](https://github.com/zoontek/react-native-permissions) library or making it part of the UMP consent flow [European User Consent page](/european-user-consent).
+
+```js
+import { check, request, PERMISSIONS, RESULTS } from 'react-native-permissions';
+
+const result = await check(PERMISSIONS.IOS.APP_TRACKING_TRANSPARENCY);
+if (result === RESULTS.DENIED) {
+  // The permission has not been requested, so request it.
+  await request(PERMISSIONS.IOS.APP_TRACKING_TRANSPARENCY);
+}
+
+const adapterStatuses = await mobileAds().initialize();
+
+// Now ads can be loaded.
+```
+
 ### European User Consent
 
 Out of the box, AdMob does not handle any related regulations which you may need to enforce on your application.


### PR DESCRIPTION
### Description

All iOS apps should request the app tracking transparency, so make this part of the installation flow.
