### PR TITLE
feat(deps)!: mobile ads sdk upgrade - ios 10.2.0 / android 21.5.0

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.kt
@@ -56,7 +56,6 @@ class ReactNativeGoogleMobileAdsAppOpenModule(reactContext: ReactApplicationCont
       activity,
       adUnitId,
       adRequest,
-      AppOpenAd.APP_OPEN_AD_ORIENTATION_PORTRAIT,
       object :
         AppOpenAd.AppOpenAdLoadCallback() {
         override fun onAdLoaded(ad: AppOpenAd) {

--- a/package.json
+++ b/package.json
@@ -41,15 +41,15 @@
   ],
   "sdkVersions": {
     "ios": {
-      "googleMobileAds": "9.14.0",
-      "googleUmp": "2.0.0"
+      "googleMobileAds": "10.2.0",
+      "googleUmp": "2.0.1"
     },
     "android": {
       "minSdk": 19,
       "targetSdk": 30,
       "compileSdk": 31,
       "buildTools": "31.0.0",
-      "googleMobileAds": "21.4.0",
+      "googleMobileAds": "21.5.0",
       "googleUmp": "2.0.0"
     }
   },


### PR DESCRIPTION
### Description

## iOS
Breaking changes:
- Ads are no longer served on iOS 11. iOS 12 is required to retrieve ads, though iOS 10 is still supported.
- Building with bitcode is no longer supported. Disabling bitcode in your mobile apps is now required to integrate the Google Mobile Ads SDK.

## Android
- Deprecated [AppOpenAd.load()](https://developers.google.com/android/reference/com/google/android/gms/ads/appopen/AppOpenAd#load(android.content.Context,%20java.lang.String,%20com.google.android.gms.ads.AdRequest,%20int,%20com.google.android.gms.ads.appopen.AppOpenAd.AppOpenAdLoadCallback)) methods that accept an orientation input parameter and added new methods that don't take an orientation input. The new methods determine the orientation at request time, matching the behavior of other full-screen formats.
- Added mediation support for app open ads.