### PR TITLE
fix(android banner): debug menu opening

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -267,7 +267,7 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
       event.merge(payload);
     }
 
-    ((ThemedReactContext) reactViewGroup.getContext())
+    reactViewGroup.getReactContext()
         .getJSModule(RCTEventEmitter.class)
         .receiveEvent(reactViewGroup.getId(), "onNativeEvent", event);
   }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -267,7 +267,8 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
       event.merge(payload);
     }
 
-    reactViewGroup.getReactContext()
+    reactViewGroup
+        .getReactContext()
         .getJSModule(RCTEventEmitter.class)
         .receiveEvent(reactViewGroup.getId(), "onNativeEvent", event);
   }

--- a/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeAdView.java
+++ b/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeAdView.java
@@ -1,6 +1,8 @@
 package io.invertase.googlemobileads.common;
 
 import android.content.Context;
+
+import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
@@ -13,9 +15,11 @@ public class ReactNativeAdView extends ReactViewGroup {
   private boolean manualImpressionsEnabled;
   private boolean propsChanged;
   private boolean isFluid;
+  private ThemedReactContext reactContext;
 
-  public ReactNativeAdView(final Context context) {
-    super(context);
+  public ReactNativeAdView(final ThemedReactContext context) {
+    super(context.getCurrentActivity());
+    setReactContext(context);
   }
 
   public void setRequest(AdRequest request) {
@@ -64,5 +68,13 @@ public class ReactNativeAdView extends ReactViewGroup {
 
   public boolean getIsFluid() {
     return this.isFluid;
+  }
+
+  public ThemedReactContext getReactContext() {
+    return reactContext;
+  }
+
+  public void setReactContext(ThemedReactContext reactContext) {
+    this.reactContext = reactContext;
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeAdView.java
+++ b/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeAdView.java
@@ -1,7 +1,5 @@
 package io.invertase.googlemobileads.common;
 
-import android.content.Context;
-
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.google.android.gms.ads.AdRequest;


### PR DESCRIPTION
### Description

unable to open the Ad Debug Menu via gesture on Android. This PR fixes that

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Fixes #188 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

Current release (10.0.0) unable to use two finger long press gesture to access debug menu on Android

With this PR, using the gesture activates the menu correctly.

iOS unaffected.

---

🔥 