### PR TITLE
feat(ads-module): open debug menu programmatically

### DIFF
--- a/RNGoogleMobileAdsExample/App.tsx
+++ b/RNGoogleMobileAdsExample/App.tsx
@@ -849,6 +849,45 @@ class GAMInterstitialTest implements Test {
   }
 }
 
+class DebugMenuTest implements Test {
+  constructor() {
+    // Android requires SDK initialization before opening the Debug Menu
+    Platform.OS === 'android' && MobileAds().initialize().catch(console.error);
+  }
+
+  getPath(): string {
+    return 'DebugMenuTest';
+  }
+
+  getTestType(): TestType {
+    return TestType.Interactive;
+  }
+
+  render(onMount: (component: any) => void): React.ReactNode {
+    return (
+      <View style={styles.testSpacing} ref={onMount}>
+        <Button
+          title="Show Ad Debug Menu"
+          onPress={() => {
+            MobileAds().openDebugMenu(TestIds.BANNER);
+          }}
+        />
+      </View>
+    );
+  }
+
+  execute(component: any, complete: (result: TestResult) => void): void {
+    let results = new TestResult();
+    try {
+      // You can do anything here, it will execute on-device + in-app. Results are aggregated + visible in-app.
+    } catch (error) {
+      results.errors.push('Received unexpected error...');
+    } finally {
+      complete(results);
+    }
+  }
+}
+
 // All tests must be registered - a future feature will allow auto-bundling of tests via configured path or regex
 Object.keys(BannerAdSize).forEach(bannerAdSize => {
   TestRegistry.registerTest(new BannerTest(bannerAdSize));
@@ -865,6 +904,7 @@ TestRegistry.registerTest(new RewardedInterstitialHookTest());
 TestRegistry.registerTest(new AdInspectorTest());
 TestRegistry.registerTest(new GAMBannerTest());
 TestRegistry.registerTest(new GAMInterstitialTest());
+TestRegistry.registerTest(new DebugMenuTest());
 
 const App = () => {
   return (

--- a/__tests__/googleMobileAds.test.ts
+++ b/__tests__/googleMobileAds.test.ts
@@ -59,5 +59,13 @@ describe('Admob', function () {
         );
       });
     });
+
+    describe('testDebugMenu', function () {
+      it('throws if adUnit is empty', function () {
+        expect(() => {
+          admob().openDebugMenu('');
+        }).toThrowError('openDebugMenu expected a non-empty string value');
+      });
+    });
   });
 });

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.java
@@ -186,4 +186,12 @@ public class ReactNativeGoogleMobileAdsModule extends ReactNativeModule {
                   });
             });
   }
+
+  @ReactMethod
+  public void openDebugMenu(final String adUnit) {
+    if (getCurrentActivity() != null) {
+      getCurrentActivity()
+          .runOnUiThread(() -> MobileAds.openDebugMenu(getCurrentActivity(), adUnit));
+    }
+  }
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsModule.m
@@ -121,4 +121,13 @@ RCT_EXPORT_METHOD(openAdInspector
                          }];
 }
 
+RCT_EXPORT_METHOD(openDebugMenu : (NSString *)adUnit) {
+  GADDebugOptionsViewController *debugOptionsViewController =
+      [GADDebugOptionsViewController debugOptionsViewControllerWithAdUnitID:adUnit];
+  [RCTSharedApplication().delegate.window.rootViewController
+      presentViewController:debugOptionsViewController
+                   animated:YES
+                 completion:nil];
+}
+
 @end

--- a/src/MobileAds.ts
+++ b/src/MobileAds.ts
@@ -75,6 +75,7 @@ class MobileAdsModule extends Module implements MobileAdsModuleInterface {
   }
 
   openDebugMenu(adUnit: string) {
+    if (!adUnit) throw new Error('googleMobileAds.openDebugMenu expected a non-empty string value');
     this.native.openDebugMenu(adUnit);
   }
 }

--- a/src/MobileAds.ts
+++ b/src/MobileAds.ts
@@ -73,6 +73,10 @@ class MobileAdsModule extends Module implements MobileAdsModuleInterface {
   openAdInspector() {
     return this.native.openAdInspector();
   }
+
+  openDebugMenu(adUnit: string) {
+    this.native.openDebugMenu(adUnit);
+  }
 }
 
 const MobileAdsInstance = new MobileAdsModule(

--- a/src/types/GoogleMobileAdsNativeModule.ts
+++ b/src/types/GoogleMobileAdsNativeModule.ts
@@ -22,4 +22,5 @@ export interface GoogleMobileAdsNativeModule {
   rewardedShow: AdShowFunction;
   rewardedInterstitialLoad: AdLoadFunction;
   rewardedInterstitialShow: AdShowFunction;
+  openDebugMenu(adUnit: string): void;
 }

--- a/src/types/MobileAdsModule.interface.ts
+++ b/src/types/MobileAdsModule.interface.ts
@@ -50,4 +50,16 @@ export interface MobileAdsModuleInterface {
    * Returns the shared event emitter instance used for all JS event routing.
    */
   emitter: EventEmitter;
+
+  /**
+   * Opens the Ad Debug Menu.
+   *
+   * Android: `initialize` needs to be called before calling this function.
+   *
+   * @see https://developers.google.com/ad-manager/mobile-ads-sdk/android/debug
+   * @see https://developers.google.com/ad-manager/mobile-ads-sdk/ios/debug
+   *
+   * @param adUnit Any valid ad unit from your Ad Manager account is sufficient to open the debug options menu.
+   */
+  openDebugMenu(adUnit: string): void;
 }


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Opening the debug menu for ads via gesture works, however if the ad is not rendering, we have no way to trigger the gesture. this PR adds the functionality to programmatically open the debug menu (eg: via a button press).

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [x] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

Run the example app and open the Debug Menu test screen. Press the button, it should show the Debug Menu.

---
 🔥 