### PR TITLE
fix(android-debug): use activity for GAM constructor only

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -20,6 +20,7 @@ package io.invertase.googlemobileads;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
@@ -42,6 +43,7 @@ import io.invertase.googlemobileads.common.ReactNativeAdView;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -156,7 +158,12 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
     }
     BaseAdView adView;
     if (ReactNativeGoogleMobileAdsCommon.isAdManagerUnit(reactViewGroup.getUnitId())) {
-      adView = new AdManagerAdView(reactViewGroup.getContext());
+      // in order to display the debug menu for GAM ads we need the activity context
+      // https://github.com/invertase/react-native-google-mobile-ads/issues/188
+      adView =
+          new AdManagerAdView(
+              Objects.requireNonNull(
+                  ((ReactContext) reactViewGroup.getContext()).getCurrentActivity()));
     } else {
       adView = new AdView(reactViewGroup.getContext());
     }


### PR DESCRIPTION
### Description

Apologies for the previous issue. This PR addresses the actual cause for the debug menu gesture, which is to use the Activity Context when instantiating the `AdManagerAdView`. Everything else should continue to use the `ThemedReactContext`/`ReactContext`.

Note: when instantiating a view inside a ViewManager, it needs to use the ThemedReactContext in the super call, due to the `onDropViewInstance` method also expecting the correct Context Type.

### Related issues

Fixes #188 
Fixes #359 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

Adaptive banners are full width again & GAM debug menu open via gesture

![image](https://user-images.githubusercontent.com/78929158/231124842-df25e4f9-69c8-4a71-861d-516986a2e0cb.png)

![image](https://user-images.githubusercontent.com/78929158/231125027-b2b927bb-0799-4513-bd7e-cbf8a6df7ffb.png)


---
🔥 