### PR TITLE
fix:  Solved issue with method recordManualImpression for GAMBannerAd

### DIFF
--- a/src/ads/GAMBannerAd.tsx
+++ b/src/ads/GAMBannerAd.tsx
@@ -27,7 +27,7 @@ export class GAMBannerAd extends React.Component<GAMBannerAdProps> {
   recordManualImpression() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.ref.current),
-      this.commonIDRecordManualImpression,
+     UIManager.getViewManagerConfig('RNGoogleMobileAdsBannerView').Commands.recordManualImpression
       undefined,
     );
   }

--- a/src/ads/GAMBannerAd.tsx
+++ b/src/ads/GAMBannerAd.tsx
@@ -22,11 +22,12 @@ import { BaseAd, GoogleMobileAdsBannerView } from './BaseAd';
 
 export class GAMBannerAd extends React.Component<GAMBannerAdProps> {
   private ref = createRef<GoogleMobileAdsBannerView>();
+  private commonIDRecordManualImpression = "1";
 
   recordManualImpression() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.ref.current),
-      'recordManualImpression',
+      this.commonIDRecordManualImpression,
       undefined,
     );
   }

--- a/src/ads/GAMBannerAd.tsx
+++ b/src/ads/GAMBannerAd.tsx
@@ -26,7 +26,9 @@ export class GAMBannerAd extends React.Component<GAMBannerAdProps> {
   recordManualImpression() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.ref.current),
-      UIManager.getViewManagerConfig('RNGoogleMobileAdsBannerView').Commands.recordManualImpression.toString(),
+      UIManager.getViewManagerConfig(
+        'RNGoogleMobileAdsBannerView',
+      ).Commands.recordManualImpression.toString(),
       undefined,
     );
   }

--- a/src/ads/GAMBannerAd.tsx
+++ b/src/ads/GAMBannerAd.tsx
@@ -26,7 +26,7 @@ export class GAMBannerAd extends React.Component<GAMBannerAdProps> {
   recordManualImpression() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.ref.current),
-      UIManager.getViewManagerConfig('RNGoogleMobileAdsBannerView').Commands.recordManualImpression,
+      UIManager.getViewManagerConfig('RNGoogleMobileAdsBannerView').Commands.recordManualImpression.toString(),
       undefined,
     );
   }

--- a/src/ads/GAMBannerAd.tsx
+++ b/src/ads/GAMBannerAd.tsx
@@ -22,12 +22,11 @@ import { BaseAd, GoogleMobileAdsBannerView } from './BaseAd';
 
 export class GAMBannerAd extends React.Component<GAMBannerAdProps> {
   private ref = createRef<GoogleMobileAdsBannerView>();
-  private commonIDRecordManualImpression = "1";
 
   recordManualImpression() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.ref.current),
-     UIManager.getViewManagerConfig('RNGoogleMobileAdsBannerView').Commands.recordManualImpression
+      UIManager.getViewManagerConfig('RNGoogleMobileAdsBannerView').Commands.recordManualImpression,
       undefined,
     );
   }


### PR DESCRIPTION

### Description
fix: for method ```recordManualImpression```  in ReactNativeGoogleMobileAdsBannerAdViewManager.java  
The Android Java code in ReactNativeGoogleMobileAdsBannerAdViewManager.java is expecting an Integer after ```Integer.parseInt``` but currently string 'recordManualImpression' is passed. 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
