### PR TITLE
fix(android): Updates AppOpenAd.load method call to compile with comgoogle.android.gms:play-services-ads version 22.0.0

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.kt
@@ -56,6 +56,7 @@ class ReactNativeGoogleMobileAdsAppOpenModule(reactContext: ReactApplicationCont
       activity,
       adUnitId,
       adRequest,
+      AppOpenAd.APP_OPEN_AD_ORIENTATION_PORTRAIT,
       object :
         AppOpenAd.AppOpenAdLoadCallback() {
         override fun onAdLoaded(ad: AppOpenAd) {


### PR DESCRIPTION
### Description

App is failing to build with google android mobile ads sdk version `22.0.0` as the `AppOpenAd::load` method signature has changed to make the 4th parameter, an orientation configuration, bumping the old 4th callback to 5th.

```
public static void load(@NonNull Context context, @NonNull String adUnitId, @NonNull AdManagerAdRequest adManagerAdRequest, @AppOpenAd.AppOpenAdOrientation int orientation, @NonNull AppOpenAdLoadCallback loadCallback)
```

Please note google documentation as well:
https://developers.google.com/admob/android/app-open#kotlin_3

I'm not sure of the criticality of orientation parameter to be dynamic as the documentation doesn't state any importance of it.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [ ✅] Yes
- My change supports the following platforms;
  - [ ✅] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No

### Test Plan

Android app building should be failing as without this update, successfully building with the update.

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
