### PR TITLE
feat(deps)!: mobile ads sdk upgrade - ios 10.5.0 / android 22.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "sdkVersions": {
     "ios": {
-      "googleMobileAds": "10.3.0",
+      "googleMobileAds": "10.5.0",
       "googleUmp": "2.0.1"
     },
     "android": {
@@ -49,7 +49,7 @@
       "targetSdk": 30,
       "compileSdk": 31,
       "buildTools": "31.0.0",
-      "googleMobileAds": "22.0.0",
+      "googleMobileAds": "22.1.0",
       "googleUmp": "2.0.0"
     }
   },


### PR DESCRIPTION
BREAKING CHANGE:
- Updated minimum supported Xcode version to 14.1.
  - armv7 is not supported in Xcode 14 and has been removed from the SDK.
- The minimum deployment target has been increased to iOS 11.0.