### PR TITLE
fix(android): fixed android build error issue for RN 0.72

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -117,7 +117,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.google.android.gms:play-services-ads:${googleMobileAdsVersion}") { force = true; }
+  implementation("com.google.android.gms:play-services-ads:${googleMobileAdsVersion}")
   api "com.google.android.ump:user-messaging-platform:${googleUmpVersion}"
 }
 


### PR DESCRIPTION
```
Build file 'project_name/node_modules/react-native-google-mobile-ads/android/build.gradle' line: 120

A problem occurred evaluating project ':react-native-google-mobile-ads'.
> Cannot set the value of read-only property 'force' for DefaultExternalModuleDependency{group='com.google.android.gms', name='play-services-ads', version='22.1.0', configuration='default'} of type org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency.
```

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `__tests__e2e__`
  - [x] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No