### PR TITLE
fix/android_support/app.config.js

### DIFF
--- a/android/app-json.gradle
+++ b/android/app-json.gradle
@@ -28,6 +28,17 @@ for (int i = 0; i <= 3; i++) {
   }
 }
 
+// Read .env file and construct env vars map
+Map<String, String> envVars = null
+File envFile = new File(parentDir, '.env')
+if (envFile.exists()) {
+  String envContent = envFile.text
+  for (String line : envContent.split('\n')) {
+    def (key, value) = line.split('=')
+    envVars[key] = value
+  }
+}
+
 if (configFile != null && configFile.exists()) {
   rootProject.logger.info ":${project.name} ${fileName} found at ${configFile.toString()}"
   Object json = null
@@ -41,7 +52,7 @@ if (configFile != null && configFile.exists()) {
       "-e",
       "console.log(JSON.stringify(require('${configFile.absolutePath}')));"
     ]
-      .execute(null, projectDir)
+      .execute(envVars, projectDir)  // Pass env vars to node process
       .text
       .trim()
     if (configOutput && !configOutput.isEmpty()) {

--- a/android/app-json.gradle
+++ b/android/app-json.gradle
@@ -1,30 +1,56 @@
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
-String fileName = "app.json"
+String[] fileNames = ["app.json", "app.config.js"]
+String fileName = null
 String jsonRoot = "react-native-google-mobile-ads"
 String jsonRaw = "GOOGLE_MOBILE_ADS_JSON_RAW"
 
-File jsonFile = null
+File configFile = null
 File parentDir = rootProject.projectDir
 
 for (int i = 0; i <= 3; i++) {
   if (parentDir == null) break
   parentDir = parentDir.parentFile
   if (parentDir != null) {
-    jsonFile = new File(parentDir, fileName)
-    if (jsonFile.exists()) break
+    configFile = new File(parentDir, fileNames[0])
+    if (configFile.exists()){
+      fileName = fileNames[0]
+      break
+    }
+    else{
+      configFile = new File(parentDir, fileNames[1])
+      if (configFile.exists()){
+        fileName = fileNames[0]
+        break
+      }
+    }
   }
 }
 
-if (jsonFile != null && jsonFile.exists()) {
-  rootProject.logger.info ":${project.name} ${fileName} found at ${jsonFile.toString()}"
+if (configFile != null && configFile.exists()) {
+  rootProject.logger.info ":${project.name} ${fileName} found at ${configFile.toString()}"
   Object json = null
 
   try {
-    json = new JsonSlurper().parseText(jsonFile.text)
+    //json = new JsonSlurper().parseText(jsonFile.text)
+    def configOutput = [
+      "node",
+      "-r",
+      "@babel/register",
+      "-e",
+      "console.log(JSON.stringify(require('${configFile.absolutePath}')));"
+    ]
+      .execute(null, projectDir)
+      .text
+      .trim()
+    if (configOutput && !configOutput.isEmpty()) {
+      json = new JsonSlurper().parseText(configOutput.toString())
+    } else {
+      rootProject.logger.warn ":${project.name} received empty output while parsing ${configFile} found at ${configFile.toString()}."
+    }
   } catch (Exception ignored) {
-    rootProject.logger.warn ":${project.name} failed to parse ${fileName} found at ${jsonFile.toString()}."
+    rootProject.logger.warn ":${project.name} failed to parse ${configFile} found at ${configFile.toString()}."
     rootProject.logger.warn ignored.toString()
   }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,7 +83,7 @@ if (!appJSONGoogleMobileAdsAppIDString) {
   println "\n\n\n"
   println "**************************************************************************************************************"
   println "\n\n\n"
-  println "ERROR: react-native-google-mobile-ads requires an 'android_app_id' property inside a 'react-native-google-mobile-ads' key in your app.json."
+  println "ERROR: react-native-google-mobile-ads requires an 'android_app_id' property inside a 'react-native-google-mobile-ads' key in your app.json/app.config.js."
   println "  No android_app_id property was found in this location. The native Google Mobile Ads SDK will crash on startup without it."
   println "\n\n\n"
   println "**************************************************************************************************************"


### PR DESCRIPTION
### Description

This pull request updates the Gradle script to support configuration files in newer JavaScript formats, such as `app.config.js`, in the React Native project. It introduces support for transpiling JavaScript code using Babel, enabling the use of modern JavaScript features.

The motivation behind this change is to enhance the library's ability to understand and parse configuration files in JavaScript, providing more flexibility for developers. The current implementation was a starting point to address this need, but it may not be the most optimal solution and introduces additional dependencies. The default export issue with newer JavaScript syntax couldn't be resolved at this time.

### Related issues

Fixes #370 

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No``