### PR TITLE
fix(android): kotlinVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
     dependencies {
       classpath("com.android.tools.build:gradle:7.0.4")
-      classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${getExtOrDefault('kotlinVersion', '1.6.10')}"
+      classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${getExtOrDefault('kotlinVersion', '1.8.22')}"
     }
   } else {
     repositories {
@@ -24,7 +24,7 @@ buildscript {
     }
 
     dependencies {
-      classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${getExtOrDefault('kotlinVersion', '1.6.10')}"
+      classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${getExtOrDefault('kotlinVersion', '1.8.22')}"
     }
   }
 }


### PR DESCRIPTION
### Description

When I wanted to build the Android package in Windows environment, I was getting an error if there was no kotlinVersion parameter in my main project. Even if there was no kotlinVersion in my main project, it was using the version 1.6.0 written in these lines. This version causes an error when building.

So I upgraded to the latest version 1.8.22 that I could run.

### Related issues

Fixes https://github.com/invertase/react-native-google-mobile-ads/issues/405

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No