### PR TITLE
fix(ios): Build support on both architectures

### DIFF
--- a/RNGoogleMobileAds.podspec
+++ b/RNGoogleMobileAds.podspec
@@ -22,7 +22,11 @@ Pod::Spec.new do |s|
   s.weak_frameworks     = "AppTrackingTransparency"
 
   # React Native dependencies
-  install_modules_dependencies(s)
+  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
+  end
 
   # Other dependencies
   if defined?($RNGoogleUmpSDKVersion)


### PR DESCRIPTION
### Description
iOS build fails on RN v0.70.x
Fixed iOS builds to work on both architectures.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No
