### PR TITLE
fix(android): race conditions getting current activity

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
@@ -16,6 +16,7 @@ package io.invertase.googlemobileads;
  * limitations under the License.
  *
  */
+import android.app.Activity;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import com.facebook.react.bridge.Arguments;
@@ -96,7 +97,9 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
 
       ConsentRequestParameters consentRequestParameters = paramsBuilder.build();
 
-      if (getCurrentActivity() == null) {
+      Activity currentActivity = getCurrentActivity();
+
+      if (currentActivity == null) {
         rejectPromiseWithCodeAndMessage(
             promise,
             "null-activity",
@@ -105,7 +108,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
       }
 
       consentInformation.requestConsentInfoUpdate(
-          getCurrentActivity(),
+          currentActivity,
           consentRequestParameters,
           () -> {
             WritableMap requestInfoMap = Arguments.createMap();
@@ -131,37 +134,38 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
   @ReactMethod
   public void showForm(final Promise promise) {
     try {
-      if (getCurrentActivity() == null) {
+      Activity currentActivity = getCurrentActivity();
+
+      if (currentActivity == null) {
         rejectPromiseWithCodeAndMessage(
             promise,
             "null-activity",
             "Consent form attempted to show but the current Activity was null.");
         return;
       }
-      getCurrentActivity()
-          .runOnUiThread(
-              () ->
-                  UserMessagingPlatform.loadConsentForm(
-                      getReactApplicationContext(),
-                      consentForm ->
-                          consentForm.show(
-                              getCurrentActivity(),
-                              formError -> {
-                                if (formError != null) {
-                                  rejectPromiseWithCodeAndMessage(
-                                      promise, "consent-form-error", formError.getMessage());
-                                } else {
-                                  WritableMap consentFormMap = Arguments.createMap();
-                                  consentFormMap.putString(
-                                      "status",
-                                      getConsentStatusString(
-                                          consentInformation.getConsentStatus()));
-                                  promise.resolve(consentFormMap);
-                                }
-                              }),
-                      formError ->
-                          rejectPromiseWithCodeAndMessage(
-                              promise, "consent-form-error", formError.getMessage())));
+
+      currentActivity.runOnUiThread(
+          () ->
+              UserMessagingPlatform.loadConsentForm(
+                  getReactApplicationContext(),
+                  consentForm ->
+                      consentForm.show(
+                          currentActivity,
+                          formError -> {
+                            if (formError != null) {
+                              rejectPromiseWithCodeAndMessage(
+                                  promise, "consent-form-error", formError.getMessage());
+                            } else {
+                              WritableMap consentFormMap = Arguments.createMap();
+                              consentFormMap.putString(
+                                  "status",
+                                  getConsentStatusString(consentInformation.getConsentStatus()));
+                              promise.resolve(consentFormMap);
+                            }
+                          }),
+                  formError ->
+                      rejectPromiseWithCodeAndMessage(
+                          promise, "consent-form-error", formError.getMessage())));
     } catch (Exception e) {
       rejectPromiseWithCodeAndMessage(promise, "consent-form-error", e.toString());
     }
@@ -170,26 +174,28 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
   @ReactMethod
   public void showPrivacyOptionsForm(final Promise promise) {
     try {
-      if (getCurrentActivity() == null) {
+      Activity currentActivity = getCurrentActivity();
+
+      if (currentActivity == null) {
         rejectPromiseWithCodeAndMessage(
             promise,
             "null-activity",
             "Privacy options form attempted to show but the current Activity was null.");
         return;
       }
-      getCurrentActivity()
-          .runOnUiThread(
-              () ->
-                  UserMessagingPlatform.showPrivacyOptionsForm(
-                      getCurrentActivity(),
-                      formError -> {
-                        if (formError != null) {
-                          rejectPromiseWithCodeAndMessage(
-                              promise, "privacy-options-form-error", formError.getMessage());
-                        } else {
-                          promise.resolve("Privacy options form presented successfully.");
-                        }
-                      }));
+
+      currentActivity.runOnUiThread(
+          () ->
+              UserMessagingPlatform.showPrivacyOptionsForm(
+                  currentActivity,
+                  formError -> {
+                    if (formError != null) {
+                      rejectPromiseWithCodeAndMessage(
+                          promise, "privacy-options-form-error", formError.getMessage());
+                    } else {
+                      promise.resolve("Privacy options form presented successfully.");
+                    }
+                  }));
     } catch (Exception e) {
       rejectPromiseWithCodeAndMessage(promise, "consent-form-error", e.toString());
     }


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
Consecutive calls to `getCurrentActivity` are not guaranteed to return the same result. Call to `getCurrentActivity` after our `null`-checks are thus part of a race condition. Calling `getCurrentActivity` only once solves this issue.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
I verified the changes using the test app

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
