### PR TITLE
feat: return updated consent status from privacy options form

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
@@ -193,7 +193,10 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
                       rejectPromiseWithCodeAndMessage(
                           promise, "privacy-options-form-error", formError.getMessage());
                     } else {
-                      promise.resolve("Privacy options form presented successfully.");
+                      WritableMap resultMap = Arguments.createMap();
+                      resultMap.putString(
+                          "status", getConsentStatusString(consentInformation.getConsentStatus()));
+                      promise.resolve(resultMap);
                     }
                   }));
     } catch (Exception e) {

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
@@ -165,7 +165,11 @@ RCT_EXPORT_METHOD(showPrivacyOptionsForm
                                                                formError.localizedDescription,
                                                          } mutableCopy]];
                                   } else {
-                                    resolve(@"Privacy options form presented successfully.");
+                                    resolve(@{
+                                      @"status" : [self
+                                          getConsentStatusString:UMPConsentInformation
+                                                                     .sharedInstance.consentStatus],
+                                    });
                                   }
                                 }];
 #endif

--- a/src/AdsConsent.ts
+++ b/src/AdsConsent.ts
@@ -26,6 +26,7 @@ import {
   AdsConsentInfo,
   AdsConsentInfoOptions,
   AdsConsentInterface,
+  AdsConsentPrivacyOptionsFormResult,
   AdsConsentUserChoices,
 } from './types/AdsConsent.interface';
 
@@ -80,7 +81,7 @@ export const AdsConsent: AdsConsentInterface = {
     return native.showForm();
   },
 
-  showPrivacyOptionsForm(): Promise<string> {
+  showPrivacyOptionsForm(): Promise<AdsConsentPrivacyOptionsFormResult> {
     return native.showPrivacyOptionsForm();
   },
 

--- a/src/types/AdsConsent.interface.ts
+++ b/src/types/AdsConsent.interface.ts
@@ -64,7 +64,7 @@ export interface AdsConsentInterface {
   /**
    * Presents a privacy options form if privacyOptionsRequirementStatus is required.
    */
-  showPrivacyOptionsForm(): Promise<string>;
+  showPrivacyOptionsForm(): Promise<AdsConsentPrivacyOptionsFormResult>;
 
   /**
    * Returns the value stored under the `IABTCF_TCString` key
@@ -150,6 +150,21 @@ export interface AdsConsentInfoOptions {
 export interface AdsConsentFormResult {
   /**
    * The consent status of the user after closing the consent form.
+   *
+   *  - `UNKNOWN`: Unknown consent status.
+   *  - `REQUIRED`: User consent required but not yet obtained.
+   *  - `NOT_REQUIRED`: User consent not required.
+   *  - `OBTAINED`: User consent already obtained.
+   */
+  status: AdsConsentStatus;
+}
+
+/**
+ * The result of a Google-rendered privacy options form.
+ */
+export interface AdsConsentPrivacyOptionsFormResult {
+  /**
+   * The consent status of the user after closing the privacy options form.
    *
    *  - `UNKNOWN`: Unknown consent status.
    *  - `REQUIRED`: User consent required but not yet obtained.


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
The user can update their consent choices from the privacy options form, just like with the normal consent form (tbh I think they are the same). After the privacy options form is dismissed by the user we're most likely interested in the updated consent.

This PR lets the `showPrivacyOptionsForm` return the updated consent status just like the `showForm` method does.

Even the implementation is the same since both `showForm` and `showPrivacyOptionsForm` make use of the `ConsentForm.OnConsentFormDismissedListener` interface whose [documentation](https://developers.google.com/interactive-media-ads/ump/android/api/reference/com/google/android/ump/ConsentForm.OnConsentFormDismissedListener.html) recommends calling `ConsentInformation.getConsentStatus` to get the updated consent status.

I'm not sure whether we should consider this a breaking change. Technically it is because we change the return type. Before the method returned a constant string which hopefully none actually used in any way in their code.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
Tried it with patch-package. Waiting for CI to turn green.

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
