### PR TITLE
feat: return consent info whenever it changes

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
@@ -70,6 +70,20 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
     }
   }
 
+  private WritableMap getConsentInformation() {
+    WritableMap consentStatusMap = Arguments.createMap();
+    consentStatusMap.putString(
+        "status", getConsentStatusString(consentInformation.getConsentStatus()));
+    consentStatusMap.putBoolean("canRequestAds", consentInformation.canRequestAds());
+    consentStatusMap.putString(
+        "privacyOptionsRequirementStatus",
+        getPrivacyOptionsRequirementStatusString(
+            consentInformation.getPrivacyOptionsRequirementStatus()));
+    consentStatusMap.putBoolean(
+        "isConsentFormAvailable", consentInformation.isConsentFormAvailable());
+    return consentStatusMap;
+  }
+
   @ReactMethod
   public void requestInfoUpdate(@Nonnull final ReadableMap options, final Promise promise) {
     try {
@@ -111,17 +125,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
           currentActivity,
           consentRequestParameters,
           () -> {
-            WritableMap requestInfoMap = Arguments.createMap();
-            requestInfoMap.putString(
-                "status", getConsentStatusString(consentInformation.getConsentStatus()));
-            requestInfoMap.putBoolean("canRequestAds", consentInformation.canRequestAds());
-            requestInfoMap.putString(
-                "privacyOptionsRequirementStatus",
-                getPrivacyOptionsRequirementStatusString(
-                    consentInformation.getPrivacyOptionsRequirementStatus()));
-            requestInfoMap.putBoolean(
-                "isConsentFormAvailable", consentInformation.isConsentFormAvailable());
-            promise.resolve(requestInfoMap);
+            promise.resolve(getConsentInformation());
           },
           formError ->
               rejectPromiseWithCodeAndMessage(
@@ -156,11 +160,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
                               rejectPromiseWithCodeAndMessage(
                                   promise, "consent-form-error", formError.getMessage());
                             } else {
-                              WritableMap consentFormMap = Arguments.createMap();
-                              consentFormMap.putString(
-                                  "status",
-                                  getConsentStatusString(consentInformation.getConsentStatus()));
-                              promise.resolve(consentFormMap);
+                              promise.resolve(getConsentInformation());
                             }
                           }),
                   formError ->
@@ -193,7 +193,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
                       rejectPromiseWithCodeAndMessage(
                           promise, "privacy-options-form-error", formError.getMessage());
                     } else {
-                      promise.resolve("Privacy options form presented successfully.");
+                      promise.resolve(getConsentInformation());
                     }
                   }));
     } catch (Exception e) {

--- a/src/AdsConsent.ts
+++ b/src/AdsConsent.ts
@@ -22,7 +22,6 @@ import { AdsConsentPurposes } from './AdsConsentPurposes';
 import { AdsConsentSpecialFeatures } from './AdsConsentSpecialFeatures';
 import { isPropertySet, isArray, isBoolean, isObject, isString } from './common';
 import {
-  AdsConsentFormResult,
   AdsConsentInfo,
   AdsConsentInfoOptions,
   AdsConsentInterface,
@@ -76,11 +75,11 @@ export const AdsConsent: AdsConsentInterface = {
     return native.requestInfoUpdate(options);
   },
 
-  showForm(): Promise<AdsConsentFormResult> {
+  showForm(): Promise<AdsConsentInfo> {
     return native.showForm();
   },
 
-  showPrivacyOptionsForm(): Promise<string> {
+  showPrivacyOptionsForm(): Promise<AdsConsentInfo> {
     return native.showPrivacyOptionsForm();
   },
 

--- a/src/types/AdsConsent.interface.ts
+++ b/src/types/AdsConsent.interface.ts
@@ -59,12 +59,12 @@ export interface AdsConsentInterface {
    *
    * ```
    */
-  showForm(): Promise<AdsConsentFormResult>;
+  showForm(): Promise<AdsConsentInfo>;
 
   /**
    * Presents a privacy options form if privacyOptionsRequirementStatus is required.
    */
-  showPrivacyOptionsForm(): Promise<string>;
+  showPrivacyOptionsForm(): Promise<AdsConsentInfo>;
 
   /**
    * Returns the value stored under the `IABTCF_TCString` key
@@ -142,21 +142,6 @@ export interface AdsConsentInfoOptions {
    * An array of test device IDs to allow.
    */
   testDeviceIdentifiers?: string[];
-}
-
-/**
- * The result of a Google-rendered consent form.
- */
-export interface AdsConsentFormResult {
-  /**
-   * The consent status of the user after closing the consent form.
-   *
-   *  - `UNKNOWN`: Unknown consent status.
-   *  - `REQUIRED`: User consent required but not yet obtained.
-   *  - `NOT_REQUIRED`: User consent not required.
-   *  - `OBTAINED`: User consent already obtained.
-   */
-  status: AdsConsentStatus;
 }
 
 /**


### PR DESCRIPTION
### Description

UMP SDK version 2.1.0 exposes a few new methods and values which are not fully accessible though our wrapper yet. This PR proposes the following changes:

1. The existing `showForm` method currently only returns the updated value of the `getConsentStatus` method. However, calling `showForm` also updates the return value of `canRequestAds` (this is new in version 2.1.0), so I propose we let `showForm` return the updated result of `canRequestAds` as well.

2. The recently added `showPrivacyOptionsForm` method is essentially the same as the `showForm` method. It also updates the return values of `getConsentStatus` and `canRequestAds`. So I propose calling it should return exactly the same result type as the `showForm` method.

3. The upstream SDK unfortunately does not clearify whether showing forms only updates the return values of `getConsentStatus` and `canRequestAds` or whether `getPrivacyOptionsRequirementStatus` and `isConsentFormAvailable` may be affected as well. So I propose we just return these values as well and use one uniform return type for all methods updating the internal `ConsentInformation` object. These methods are: `showForm`, `showPrivacyOptionsForm` and `requestInfoUpdate`.

Alternative:

@dylancom mentionend in #433 that we might want to stay closed to the SDKs API. In this case we would have to change the return types of `showForm`, `showPrivacyOptionsForm` and `requestInfoUpdate` to `Promise<void>` and introduce a new method returning the state of the internal `ConsentInformation` object. I can create a PR for that as well, but IMHO this approach is more practical, it's also in line with our existing API.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
Ran tests and the example app.

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
