### PR TITLE
feat(consent): expose the new loadAndShowConsentFormIfRequired method

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
@@ -202,6 +202,37 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
   }
 
   @ReactMethod
+  public void loadAndShowConsentFormIfRequired(final Promise promise) {
+    try {
+      Activity currentActivity = getCurrentActivity();
+
+      if (currentActivity == null) {
+        rejectPromiseWithCodeAndMessage(
+            promise,
+            "null-activity",
+            "Consent form attempted to load and show if required but the current Activity was"
+                + " null.");
+        return;
+      }
+
+      currentActivity.runOnUiThread(
+          () ->
+              UserMessagingPlatform.loadAndShowConsentFormIfRequired(
+                  currentActivity,
+                  formError -> {
+                    if (formError != null) {
+                      rejectPromiseWithCodeAndMessage(
+                          promise, "consent-form-error", formError.getMessage());
+                    } else {
+                      promise.resolve(getConsentInformation());
+                    }
+                  }));
+    } catch (Exception e) {
+      rejectPromiseWithCodeAndMessage(promise, "consent-form-error", e.toString());
+    }
+  }
+
+  @ReactMethod
   public void reset() {
     consentInformation.reset();
   }

--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -130,9 +130,7 @@ import { AdsConsent, AdsConsentStatus } from 'react-native-google-mobile-ads';
 
 const consentInfo = await AdsConsent.requestInfoUpdate();
 
-if (consentInfo.isConsentFormAvailable && consentInfo.status === AdsConsentStatus.REQUIRED) {
-  const { status } = await AdsConsent.showForm();
-}
+const { status } = await AdsConsent.loadAndShowConsentFormIfRequired();
 ```
 
 > Do not persist the status. You could however store this locally in application state (e.g. React Context) and update the status on every app launch as it may change.

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
@@ -168,6 +168,29 @@ RCT_EXPORT_METHOD(showPrivacyOptionsForm
 #endif
 }
 
+RCT_EXPORT_METHOD(loadAndShowConsentFormIfRequired
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+#if !TARGET_OS_MACCATALYST
+  [UMPConsentForm
+      loadAndPresentIfRequiredFromViewController:[UIApplication sharedApplication]
+                                                     .delegate.window.rootViewController
+                               completionHandler:^(NSError *_Nullable formError) {
+                                 if (formError) {
+                                   [RNSharedUtils
+                                       rejectPromiseWithUserInfo:reject
+                                                        userInfo:[@{
+                                                          @"code" : @"consent-form-error",
+                                                          @"message" :
+                                                              formError.localizedDescription,
+                                                        } mutableCopy]];
+                                 } else {
+                                   resolve([self getConsentInformation]);
+                                 }
+                               }];
+#endif
+}
+
 RCT_EXPORT_METHOD(reset) {
 #if !TARGET_OS_MACCATALYST
   [UMPConsentInformation.sharedInstance reset];

--- a/src/AdsConsent.ts
+++ b/src/AdsConsent.ts
@@ -83,6 +83,10 @@ export const AdsConsent: AdsConsentInterface = {
     return native.showPrivacyOptionsForm();
   },
 
+  loadAndShowConsentFormIfRequired(): Promise<AdsConsentInfo> {
+    return native.loadAndShowConsentFormIfRequired();
+  },
+
   reset(): void {
     return native.reset();
   },

--- a/src/types/AdsConsent.interface.ts
+++ b/src/types/AdsConsent.interface.ts
@@ -67,6 +67,13 @@ export interface AdsConsentInterface {
   showPrivacyOptionsForm(): Promise<AdsConsentInfo>;
 
   /**
+   * Loads a consent form and immediately presents it if consentStatus is required.
+   *
+   * This method is intended for the use case of showing a form if needed when the app starts.
+   */
+  loadAndShowConsentFormIfRequired(): Promise<AdsConsentInfo>;
+
+  /**
    * Returns the value stored under the `IABTCF_TCString` key
    * in NSUserDefaults (iOS) / SharedPreferences (Android) as
    * defined by the IAB Europe Transparency & Consent Framework.


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
Version 2.1.0 of the UMP SDK added a new `loadAndShowConsentFormIfRequired` method. This PR exposes this method and recommends it in our docs over the old approach.

With this new method consent can be obtained like this:

```ts
import { AdsConsent, AdsConsentStatus } from 'react-native-google-mobile-ads';

const consentInfo = await AdsConsent.requestInfoUpdate();

const { status } = await AdsConsent.loadAndShowConsentFormIfRequired();
```

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->
This release features a new `loadAndShowConsentFormIfRequired` method which simplifies obtaining consent from users.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
CI + local test with patch-package

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
