### PR TITLE
fix: missing events of type GAMAdEventType in addAdEventListener

### DIFF
--- a/src/ads/MobileAd.ts
+++ b/src/ads/MobileAd.ts
@@ -147,6 +147,7 @@ export abstract class MobileAd implements MobileAdInterface {
     if (
       !(
         isOneOf(type, Object.values(AdEventType)) ||
+        isOneOf(type, Object.values(GAMAdEventType)) ||
         (isOneOf(type, Object.values(RewardedAdEventType)) &&
           (this._type === 'rewarded' || this._type === 'rewarded_interstitial'))
       )


### PR DESCRIPTION
### Description

I tried to call addAdEventListener on a GAMInterstitialAd for events of type GAMAdEventType.APP_EVENT. However, an error was thrown:

"GAMInterstitialAd.addAdEventListener(*) 'type' expected a valid event type value."

After checking the source code, the issue is in the implementation of `_addAdEventListener`: the filter is missing the type GAMAdEventType.

### Related issues

Fixes #444 

### Release Summary

Fix: missing events of type GAMAdEventType in addAdEventListener

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [ x ] Yes
- My change supports the following platforms;
  - [ x ] `Android`
  - [ x ] `iOS`
- This is a breaking change;
  - [ ] Yes
  - [ x ] No

