### PR TITLE
fix(android): race condition getting current activity

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -44,7 +44,6 @@ import io.invertase.googlemobileads.common.SharedUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.json.JSONException;
@@ -167,13 +166,11 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
     }
     BaseAdView adView;
     if (ReactNativeGoogleMobileAdsCommon.isAdManagerUnit(reactViewGroup.getUnitId())) {
-      if (((ReactContext) reactViewGroup.getContext()).getCurrentActivity() != null) {
+      Activity currentActivity = ((ReactContext) reactViewGroup.getContext()).getCurrentActivity();
+      if (currentActivity != null) {
         // in order to display the debug menu for GAM ads we need the activity context
         // https://github.com/invertase/react-native-google-mobile-ads/issues/188
-        adView =
-            new AdManagerAdView(
-                Objects.requireNonNull(
-                    ((ReactContext) reactViewGroup.getContext()).getCurrentActivity()));
+        adView = new AdManagerAdView(currentActivity);
       } else {
         return null;
       }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -17,6 +17,7 @@ package io.invertase.googlemobileads;
  *
  */
 
+import android.app.Activity;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Arguments;


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
The just merged #436 introduces a race condition like the ones fixed in #418.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
This change is simple enough to verify by review and green CI.

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
