### PR TITLE
fix: banners not properly destroyed

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -158,6 +158,20 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
     reactViewGroup.setPropsChanged(false);
   }
 
+  @Override
+  public void onDropViewInstance(@NonNull ReactNativeAdView reactViewGroup) {
+    BaseAdView adView = getAdView(reactViewGroup);
+    if (adView != null) {
+      adView.setAdListener(null);
+      if (adView instanceof AdManagerAdView) {
+        ((AdManagerAdView) adView).setAppEventListener(null);
+      }
+      adView.destroy();
+      reactViewGroup.removeView(adView);
+    }
+    super.onDropViewInstance(reactViewGroup);
+  }
+
   private BaseAdView initAdView(ReactNativeAdView reactViewGroup) {
     BaseAdView oldAdView = getAdView(reactViewGroup);
     if (oldAdView != null) {

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.m
@@ -23,6 +23,13 @@
 
 @implementation RNGoogleMobileAdsBannerComponent
 
+- (void)dealloc {
+  if (_banner) {
+    [_banner removeFromSuperview];
+    _banner = nil;
+  }
+}
+
 - (void)didSetProps:(NSArray<NSString *> *)changedProps {
   if (_propsChanged) {
     [self requestAd];

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerView.mm
@@ -94,6 +94,13 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+- (void)dealloc {
+  if (_banner) {
+    [_banner removeFromSuperview];
+    _banner = nil;
+  }
+}
+
 #pragma mark - Methods
 
 - (void)initBanner:(GADAdSize)adSize {


### PR DESCRIPTION
### Description
Added methods to clean up the banner when a bannerView unmounts.

Might fix #496?

Please test.
