### PR TITLE
feat: initialize sdk in parallel

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
@@ -233,6 +233,11 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
   }
 
   @ReactMethod
+  public void getConsentInfo(Promise promise) {
+    promise.resolve(getConsentInformation());
+  }
+
+  @ReactMethod
   public void reset() {
     consentInformation.reset();
   }

--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -95,11 +95,55 @@ see [Inspecting consent choices] below.
 
 ### Gathering user consent
 
-To request consent, call these methods as early as possible within your app before presenting any ads.
-Once the user has selected their preference, the `showForm` method returns an `AdsConsentFormResult` interface, containing the updated consent status:
+You should request an update of the user's consent information at every app launch, using `requestInfoUpdate`.
+This determines whether your user needs to provide consent if they haven't done so already, or if their consent has expired.
+
+After you have received the most up-to-date consent status, call `loadAndShowConsentFormIfRequired` to load a consent form.
+If the consent status is required, the SDK loads a form and immediately presents it.
+The completion handler is called after the form is dismissed. If consent is not required, the completion handler is called immediately.
+
+Before requesting ads in your app, check if you have obtained consent from the user using `canRequestAds`.
+If an error occurs during the consent gathering process, you should still attempt to request ads.
+The UMP SDK uses the consent status from the previous session.
 
 ```js
-import { AdsConsent, AdsConsentStatus } from 'react-native-google-mobile-ads';
+import mobileAds, { AdsConsent, AdsConsentStatus } from 'react-native-google-mobile-ads';
+
+const isMobileAdsStartCalled = false;
+
+// Request an update for the consent information.
+AdsConsent.requestInfoUpdate().then(() => {
+
+  AdsConsent.loadAndShowConsentFormIfRequired().then(adsConsentInfo => {
+
+    // Consent has been gathered.
+    if (adsConsentInfo.canRequestAds) {
+      startGoogleMobileAdsSDK()
+    }
+  })
+})
+
+// Check if you can initialize the Google Mobile Ads SDK in parallel
+// while checking for new consent information. Consent obtained in
+// the previous session can be used to request ads.
+// So you can start loading ads as soon as possible after your app launches.
+const {canRequestAds} = await AdsConsent.getConsentInfo()
+if (canRequestAds) {
+  startGoogleMobileAdsSDK()
+}
+
+async function startGoogleMobileAdsSDK() {
+  if (isMobileAdsStartCalled) return;
+
+  isMobileAdsStartCalled = true;
+
+  // (iOS) Handle Apple's App Tracking Transparency.
+
+  // Initialize the Google Mobile Ads SDK.
+  await mobileAds().initialize()
+
+  // Request an ad...
+}
 
 const consentInfo = await AdsConsent.requestInfoUpdate();
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
@@ -197,6 +197,12 @@ RCT_EXPORT_METHOD(reset) {
 #endif
 }
 
+RCT_EXPORT_METHOD(getConsentInfo
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+  resolve([self getConsentInformation]);
+}
+
 RCT_EXPORT_METHOD(getTCString : (RCTPromiseResolveBlock)resolve : (RCTPromiseRejectBlock)reject) {
   @try {
     // https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#in-app-details

--- a/src/AdsConsent.ts
+++ b/src/AdsConsent.ts
@@ -87,6 +87,10 @@ export const AdsConsent: AdsConsentInterface = {
     return native.loadAndShowConsentFormIfRequired();
   },
 
+  getConsentInfo(): Promise<AdsConsentInfo> {
+    return native.getConsentInfo();
+  },
+
   reset(): void {
     return native.reset();
   },

--- a/src/types/AdsConsent.interface.ts
+++ b/src/types/AdsConsent.interface.ts
@@ -74,6 +74,19 @@ export interface AdsConsentInterface {
   loadAndShowConsentFormIfRequired(): Promise<AdsConsentInfo>;
 
   /**
+   * Returns the UMP Consent Information from the last known session.
+   *
+   * #### Example
+   *
+   * ```js
+   * import { AdsConsent } from '@invertase/react-native-google-ads';
+   *
+   * const consentInfo = await AdsConsent.getConsentInfo();
+   * ```
+   */
+  getConsentInfo(): Promise<AdsConsentInfo>;
+
+  /**
    * Returns the value stored under the `IABTCF_TCString` key
    * in NSUserDefaults (iOS) / SharedPreferences (Android) as
    * defined by the IAB Europe Transparency & Consent Framework.


### PR DESCRIPTION
### Description

As a latency best practice, Google recommends not waiting for the loadAndPresentIfRequired callback to complete so you can start loading ads as soon as possible after your app launches.

This PR adds a method that directly exposes the UMP Consent Information without having to wait for callbacks.
And so the SDK can be initialized faster if consent was obtained in a previous session.

See:
https://developers.google.com/admob/ios/privacy#request-ads
https://developers.google.com/admob/android/privacy#request-ads
