### PR TITLE
feat: add method to check if consent for purpose 1 was given

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
@@ -266,4 +266,16 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
       rejectPromiseWithCodeAndMessage(promise, "consent-string-error", e.toString());
     }
   }
+
+  @ReactMethod
+  public void getPurposeConsents(Promise promise) {
+    try {
+      SharedPreferences prefs =
+          PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
+      String purposeConsents = prefs.getString("IABTCF_PurposeConsents", "");
+      promise.resolve(purposeConsents);
+    } catch (Exception e) {
+      rejectPromiseWithCodeAndMessage(promise, "consent-string-error", e.toString());
+    }
+  }
 }

--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -77,7 +77,8 @@ npx react-native run-android
 
 ### App Tracking Transparency
 
-If you want to handle Apple's App Tracking Transparency requirements, ensure you've configured and published your [ATT message](https://developers.google.com/admob/ump/ios/quick-start#app_tracking_transparency) in your Google AdMob account.
+If you configure an [ATT message](https://support.google.com/admob/answer/10115331) in your Google AdMob account, the UMP SDK will automatically handle the ATT alert.
+This will also show an IDFA explainer message. If you don't want to show an explainer message you can show the ATT alert [manually](https://docs.page/invertase/react-native-google-mobile-ads#app-tracking-transparency-ios).
 Also, within your projects `app.json` file, you have to use the `user_tracking_usage_description` to to describe your usage:
 
 ```json
@@ -164,7 +165,12 @@ async function startGoogleMobileAdsSDK() {
 
   isMobileAdsStartCalled = true;
 
-  // (iOS) Handle Apple's App Tracking Transparency.
+  // (Optional, iOS) Handle Apple's App Tracking Transparency manually.
+  const gdprApplies = await AdsConsent.getGdprApplies();
+  const hasConsentForPurposeOne = gdprApplies ? (await AdsConsent.getPurposeConsents()).startsWith("1") : false;
+  if (!gdprApplies || hasConsentForPurposeOne) {
+    // Request ATT...
+  }
 
   // Initialize the Google Mobile Ads SDK.
   await mobileAds().initialize()

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
@@ -232,4 +232,20 @@ RCT_EXPORT_METHOD(getGdprApplies
   }
 }
 
+RCT_EXPORT_METHOD(getPurposeConsents
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+  @try {
+    NSString *purposeConsents =
+        [[NSUserDefaults standardUserDefaults] stringForKey:@"IABTCF_PurposeConsents"];
+    resolve(purposeConsents);
+  } @catch (NSError *error) {
+    [RNSharedUtils rejectPromiseWithUserInfo:reject
+                                    userInfo:[@{
+                                      @"code" : @"consent-string-error",
+                                      @"message" : error.localizedDescription,
+                                    } mutableCopy]];
+  }
+}
+
 @end

--- a/src/AdsConsent.ts
+++ b/src/AdsConsent.ts
@@ -108,6 +108,10 @@ export const AdsConsent: AdsConsentInterface = {
     return native.getGdprApplies();
   },
 
+  getPurposeConsents(): Promise<string> {
+    return native.getPurposeConsents();
+  },
+
   async getUserChoices(): Promise<AdsConsentUserChoices> {
     const tcString = await native.getTCString();
 

--- a/src/types/AdsConsent.interface.ts
+++ b/src/types/AdsConsent.interface.ts
@@ -137,6 +137,26 @@ export interface AdsConsentInterface {
   getGdprApplies(): Promise<boolean>;
 
   /**
+   * Returns the value stored under the `IABTCF_PurposeConsents` key
+   * in NSUserDefaults (iOS) / SharedPreferences (Android) as
+   * defined by the IAB Europe Transparency & Consent Framework.
+   *
+   * More information available here:
+   * https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#in-app-details
+   *
+   * #### Example
+   *
+   * ```js
+   * import { AdsConsent } from '@invertase/react-native-google-ads';
+   *
+   * await AdsConsent.requestInfoUpdate();
+   * const purposeConsents = await AdsConsent.getPurposeConsents();
+   * const hasConsentForPurposeOne = purposeConsents.startsWith("1");
+   * ```
+   */
+  getPurposeConsents(): Promise<string>;
+
+  /**
    * Provides information about a user's consent choices.
    *
    * #### Example


### PR DESCRIPTION
### Description

This feature makes it possible to only show the ATT alert if consent (for Purpose 1) was given.
As advised by: https://developers.google.com/admob/ios/privacy/gdpr#frequently_asked_questions

See also: https://developers.google.com/admob/ios/privacy/gdpr#how_to_read_consent_choices
