### PR TITLE
fix(consent): wrong value of user's consent to 'Create a personalized content profile' purpose

### DIFF
--- a/src/AdsConsent.ts
+++ b/src/AdsConsent.ts
@@ -139,7 +139,7 @@ export const AdsConsent: AdsConsentInterface = {
         AdsConsentPurposes.CREATE_A_PERSONALISED_ADS_PROFILE,
       ),
       createAPersonalisedContentProfile: tcModel.purposeConsents.has(
-        AdsConsentPurposes.CREATE_A_PERSONALISED_ADS_PROFILE,
+        AdsConsentPurposes.CREATE_A_PERSONALISED_CONTENT_PROFILE,
       ),
       developAndImproveProducts: tcModel.purposeConsents.has(
         AdsConsentPurposes.DEVELOP_AND_IMPROVE_PRODUCTS,


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
This PR fixes the wrong value returned by AdsConsent.getUserChoices() for the createAPersonalisedContentProfile variable.
The createAPersonalisedContentProfile is compared to AdsConsentPurposes.CREATE_A_PERSONALISED_ADS_PROFILE while it should be compared to AdsConsentPurposes.CREATE_A_PERSONALISED_CONTENT_PROFILE.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
:fire:
