### PR TITLE
feat(deps)!: mobile ads sdk upgrade - ios 11.0.1, ump sdk 2.2.0

### DIFF
--- a/RNGoogleMobileAds.podspec
+++ b/RNGoogleMobileAds.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.authors             = "Invertase Limited"
   s.source              = { :git => "#{package["repository"]["url"]}.git", :tag => "v#{s.version}" }
   s.social_media_url    = 'http://twitter.com/invertaseio'
-  s.ios.deployment_target = "10.0"
+  s.ios.deployment_target = "12.0"
   s.source_files        = "ios/**/*.{h,m,mm,swift}"
   s.weak_frameworks     = "AppTrackingTransparency"
 

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   ],
   "sdkVersions": {
     "ios": {
-      "googleMobileAds": "10.14.0",
-      "googleUmp": "2.1.0"
+      "googleMobileAds": "11.0.1",
+      "googleUmp": "2.2.0"
     },
     "android": {
       "minSdk": 19,
@@ -50,7 +50,7 @@
       "compileSdk": 33,
       "buildTools": "33.0.0",
       "googleMobileAds": "22.5.0",
-      "googleUmp": "2.1.0"
+      "googleUmp": "2.2.0"
     }
   },
   "react-native-builder-bob": {


### PR DESCRIPTION
### Description

BREAKING CHANGES:
- The SDK no longer depends directly on GoogleAppMeasurement. To continue collecting user metrics in AdMob, link your AdMob app to Firebase and integrate the Google Analytics for Firebase SDK into your app.
- Updated the minimum supported Xcode version to 15.1.
- Increased iOS minimum deployment target to 12.0.
- Updated the minimum OS required to receive ads to iOS 13.