### PR TITLE
fix(banner, ios): fixed memory leak

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.m
@@ -117,15 +117,17 @@
   [self addSubview:_banner];
   _banner.adUnitID = _unitId;
   [self setRequested:YES];
-
-  RNGoogleMobileAdsBannerComponent * __weak weakSelf = self;
+  __weak typeof(self) weakSelf = self;
   _banner.paidEventHandler = ^(GADAdValue *_Nonnull value) {
-    [weakSelf sendEvent:@"onPaid"
-            payload:@{
-              @"value" : value.value,
-              @"precision" : @(value.precision),
-              @"currency" : value.currencyCode,
-            }];
+    typeof(self) strongSelf = weakSelf;
+    if (strongSelf) {
+      [strongSelf sendEvent:@"onPaid"
+                  payload:@{
+        @"value" : value.value,
+        @"precision" : @(value.precision),
+        @"currency" : value.currencyCode,
+      }];
+    }
   };
   [_banner loadRequest:[RNGoogleMobileAdsCommon buildAdRequest:_request]];
   [self sendEvent:@"onSizeChange"

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.m
@@ -117,8 +117,10 @@
   [self addSubview:_banner];
   _banner.adUnitID = _unitId;
   [self setRequested:YES];
+
+  RNGoogleMobileAdsBannerComponent * __weak weakSelf = self;
   _banner.paidEventHandler = ^(GADAdValue *_Nonnull value) {
-    [self sendEvent:@"onPaid"
+    [weakSelf sendEvent:@"onPaid"
             payload:@{
               @"value" : value.value,
               @"precision" : @(value.precision),


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

https://github.com/invertase/react-native-google-mobile-ads/issues/496

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

- Fixes memory leak when using banners on iOS with old RN architecture.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
