### PR TITLE
feat(android): Add support for ArrayList

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
@@ -179,9 +179,8 @@ public class ReactNativeGoogleMobileAdsCommon {
       for (Map.Entry<String, Object> entry : customTargeting.entrySet()) {
         String key = entry.getKey();
         Object value = entry.getValue();
-        String type = value.getClass().getSimpleName();
 
-        if (type.equals("String")) {
+        if (value instanceof String) {
           String finalValue = (String) value;
           builder.addCustomTargeting(key, finalValue);
         } else {

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
@@ -177,9 +177,16 @@ public class ReactNativeGoogleMobileAdsCommon {
       Map<String, Object> customTargeting = adRequestOptions.getMap("customTargeting").toHashMap();
 
       for (Map.Entry<String, Object> entry : customTargeting.entrySet()) {
-        String key = entry.getKey();
-        String value = (String) entry.getValue();
-        builder.addCustomTargeting(key, value);
+        Object value = entry.getValue();
+        String type = value.getClass().getSimpleName();
+
+        if (type.equals("String")) {
+          String finalValue = (String) value;
+          builder.addCustomTargeting(key, finalValue);
+        } else {
+          ArrayList finalValue = (ArrayList) value;
+          builder.addCustomTargeting(key, finalValue);
+        }
       }
     }
 

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
@@ -177,6 +177,7 @@ public class ReactNativeGoogleMobileAdsCommon {
       Map<String, Object> customTargeting = adRequestOptions.getMap("customTargeting").toHashMap();
 
       for (Map.Entry<String, Object> entry : customTargeting.entrySet()) {
+        String key = entry.getKey();
         Object value = entry.getValue();
         String type = value.getClass().getSimpleName();
 

--- a/src/types/RequestOptions.ts
+++ b/src/types/RequestOptions.ts
@@ -74,9 +74,9 @@ export interface RequestOptions {
   /**
    * key-value pairs used for custom targeting
    *
-   * Takes an array of string key/value pairs.
+   * Takes an object of keys with values of string or array of strings.
    */
-  customTargeting?: { [key: string]: string };
+  customTargeting?: { [key: string]: string | string[] };
 
   /**
    * Sets the request agent string to identify the ad request's origin. Third party libraries that reference the Mobile


### PR DESCRIPTION
### Description

`AdManagerAdRequest.Builder().addCustomTargeting` supports passing both strings and ArrayLists. iOS already handles this.

### Release Summary

- Add support for string[] in `customTargeting`

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

iOS ad loaded with strings and string[] in customTargeting:
![Screenshot 2024-05-10 at 2 58 04 PM](https://github.com/invertase/react-native-google-mobile-ads/assets/4458812/dcf05c7d-394d-4d33-87c8-f805f92bfd20)

Android
![Screenshot_20240510_152417_Axios](https://github.com/invertase/react-native-google-mobile-ads/assets/4458812/d0965f88-c0f4-45e3-a7dd-d95b121618ec)
