### PR TITLE
fix: Unsupported top level event type "topNative" dispatched

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/OnNativeEvent.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/OnNativeEvent.kt
@@ -16,6 +16,6 @@ class OnNativeEvent(viewId: Int, private val event: WritableMap) : Event<OnNativ
     }
 
     companion object {
-        const val EVENT_NAME = "topNative"
+        const val EVENT_NAME = "topNativeEvent"
     }
 }


### PR DESCRIPTION
When I added a Banner ad to the screen with Bridgeless and Fabric enabled, I got an error like below.

```
Error: Unsupported top level event type "topNative" dispatched
```

<img width="841" alt="Ekran Resmi 2024-05-14 14 35 11" src="https://github.com/invertase/react-native-google-mobile-ads/assets/27302986/aa7b0db1-1422-4701-8873-faa9699da2ff">

### The Solution

In _node_modules/react-native/.../ReactFabric-dev.js_ file, when I got to the relevant place, I saw that there is no "**topNative**".

I saw that there is "**topNativeEvent**" similar to this.

<img width="739" alt="Ekran Resmi 2024-05-14 15 31 59" src="https://github.com/invertase/react-native-google-mobile-ads/assets/27302986/57d91e97-b215-4476-ab6f-aedadecdd319">

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
