### PR TITLE
fix: Typescript error in the docs

### DIFF
--- a/docs/displaying-ads.mdx
+++ b/docs/displaying-ads.mdx
@@ -407,7 +407,7 @@ const adUnitId = __DEV__ ? TestIds.ADAPTIVE_BANNER : 'ca-app-pub-xxxxxxxxxxxxx/y
 
 function App() {
   const appState = useRef(AppState.currentState);
-  const [key, setKey] = useState(Date.now());
+  const [key, setKey] = useState(`banner-${Date.now()}`);
 
   // WKWebView can terminate if app is in a "suspended state", resulting in an empty banner when app returns to foreground.
   // A Google Mobile Ads Advisor suggests requesting a new ad when the app is foregrounded.


### PR DESCRIPTION
### Description

The code provided by the docs creates a TypeScript error: "Argument of type 'string' is not assignable to parameter of type 'SetStateAction<number>'.ts(2345)." By initially setting the state to a string, the error is fixed.