### PR TITLE
feat!: [BREAKING CHANGE]: Use `extra` instead of root

### DIFF
--- a/android/app-json.gradle
+++ b/android/app-json.gradle
@@ -21,7 +21,7 @@ for (int i = 0; i <= 3; i++) {
     else {
       configFile = new File(parentDir, fileNames[1])
       if (configFile.exists()) {
-        fileName = fileNames[0]
+        fileName = fileNames[1]
         break
       }
     }
@@ -33,17 +33,11 @@ if (configFile != null && configFile.exists()) {
   Object json = null
 
   try {
-    // On windows, we need to escape path separators in the path before exec'ing shell
     def configFileAbsolutePath = configFile.absolutePath
     if (System.properties['os.name'].toLowerCase().contains('windows')) {
         configFileAbsolutePath = configFileAbsolutePath.replace("\\", "\\\\")
     }
-    // rootProject.logger.warn "have a path of ${configFileAbsolutePath}"
 
-    // The config may be either in Expo javascript (app.config.js) or JSON (app.json)
-    // If it is configured in Expo javascript, requiring it will generate a config
-    // If it is configured in JSON, requiring it will also generate the config
-    // So, use node to pull in the config file to get us a JSON string for either case
     def configOutput = new StringBuffer();
     def configReadProc = [
       "node",
@@ -53,7 +47,6 @@ if (configFile != null && configFile.exists()) {
     .execute(null, projectDir)
     configReadProc.waitForProcessOutput(configOutput, System.err)
     configOutput = configOutput.toString().trim()
-    // rootProject.logger.warn "got configOutput of ${configOutput.toString()}"
 
     if (configOutput && !configOutput.isEmpty()) {
       json = new JsonSlurper().parseText(configOutput)
@@ -65,18 +58,30 @@ if (configFile != null && configFile.exists()) {
     rootProject.logger.warn ignored.toString()
   }
 
-  if (json && json[jsonRoot]) {
-    String jsonStr = JsonOutput.toJson(JsonOutput.toJson(json[jsonRoot]))
+  def getAdsConfig = { x ->
+    if (x?.expo?.extra?.get(jsonRoot)) {
+      return x.expo.extra[jsonRoot]
+    } else if (x?.extra?.get(jsonRoot)) {
+      return x.extra[jsonRoot]
+    } else if (x?.get(jsonRoot)) {
+      return x[jsonRoot]
+    } else {
+      return null
+    }
+  }
+
+  def adsConfig = getAdsConfig(json)
+
+  if (adsConfig != null) {
+    String jsonStr = JsonOutput.toJson(JsonOutput.toJson(adsConfig))
 
     rootProject.ext.googleMobileAdsJson = [
-      raw: json[jsonRoot],
+      raw: adsConfig,
       isFlagEnabled: { key, defaultValue ->
-        if (json[jsonRoot] == null || json[jsonRoot][key] == null) return defaultValue
-        return json[jsonRoot][key] == true ? true : false
+        return adsConfig[key] == true ? true : defaultValue
       },
       getStringValue: { key, defaultValue ->
-        if (json[jsonRoot] == null) return defaultValue
-        return json[jsonRoot][key] ? json[jsonRoot][key] : defaultValue
+        return adsConfig[key] ? adsConfig[key] : defaultValue
       }
     ]
 

--- a/ios_config.sh
+++ b/ios_config.sh
@@ -61,7 +61,7 @@ function setPlistValue {
 
 function getJsonKeyValue () {
   if [[ ${_RN_ROOT_EXISTS} ]]; then
-    ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$1'); puts output['extra']['react-native-google-mobile-ads']['$2']"
+    ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$1'); puts output['expo']['extra']['react-native-google-mobile-ads']['$2']"
   else
     echo ""
   fi;
@@ -115,11 +115,11 @@ if [[ ${_SEARCH_RESULT} ]]; then
     _JSON_OUTPUT_RAW=$(cat "${_SEARCH_RESULT}")
   fi;
 
-  _RN_ROOT_EXISTS=$(ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output['extra']['react-native-google-mobile-ads']" || echo '')
+  _RN_ROOT_EXISTS=$(ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output['expo']['extra']['react-native-google-mobile-ads']" || echo '')
 
   if [[ ${_RN_ROOT_EXISTS} ]]; then
     if ! python3 --version >/dev/null 2>&1; then echo "python3 not found, app.json file processing error." && exit 1; fi
-    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64;print(base64.b64encode(bytes(json.dumps(json.loads(open('"'${_SEARCH_RESULT}'"', '"'rb'"').read())['extra']['react-native-google-mobile-ads']), '"'utf-8'"')).decode())' || echo "e30=")
+    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64;print(base64.b64encode(bytes(json.dumps(json.loads(open('"'${_SEARCH_RESULT}'"', '"'rb'"').read())['expo']['extra']['react-native-google-mobile-ads']), '"'utf-8'"')).decode())' || echo "e30=")
   fi
 
   _PLIST_ENTRY_KEYS+=("google_mobile_ads_json_raw")

--- a/ios_config.sh
+++ b/ios_config.sh
@@ -40,7 +40,6 @@ _SEARCH_RESULT=''
 _RN_ROOT_EXISTS=''
 _CURRENT_LOOKUPS=1
 _PROJECT_ABBREVIATION="RNGoogleMobileAds"
-_JSON_ROOT="'react-native-google-mobile-ads'"
 _JSON_FILE_NAME='app.json'
 _JS_APP_CONFIG_FILE_NAME='app.config.js'
 _JSON_OUTPUT_BASE64='e30=' # { }
@@ -62,7 +61,7 @@ function setPlistValue {
 
 function getJsonKeyValue () {
   if [[ ${_RN_ROOT_EXISTS} ]]; then
-    ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$1'); puts output[$_JSON_ROOT]['$2']"
+    ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$1'); puts output['extra']['react-native-google-mobile-ads']['$2']"
   else
     echo ""
   fi;
@@ -116,11 +115,11 @@ if [[ ${_SEARCH_RESULT} ]]; then
     _JSON_OUTPUT_RAW=$(cat "${_SEARCH_RESULT}")
   fi;
 
-  _RN_ROOT_EXISTS=$(ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output[$_JSON_ROOT]" || echo '')
+  _RN_ROOT_EXISTS=$(ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output['extra']['react-native-google-mobile-ads']" || echo '')
 
   if [[ ${_RN_ROOT_EXISTS} ]]; then
     if ! python3 --version >/dev/null 2>&1; then echo "python3 not found, app.json file processing error." && exit 1; fi
-    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64;print(base64.b64encode(bytes(json.dumps(json.loads(open('"'${_SEARCH_RESULT}'"', '"'rb'"').read())['${_JSON_ROOT}']), '"'utf-8'"')).decode())' || echo "e30=")
+    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64;print(base64.b64encode(bytes(json.dumps(json.loads(open('"'${_SEARCH_RESULT}'"', '"'rb'"').read())['extra']['react-native-google-mobile-ads']), '"'utf-8'"')).decode())' || echo "e30=")
   fi
 
   _PLIST_ENTRY_KEYS+=("google_mobile_ads_json_raw")
@@ -215,4 +214,3 @@ for plist in "${_TARGET_PLIST}" "${_DSYM_PLIST}" ; do
 done
 
 echo "info: <- ${_PROJECT_ABBREVIATION} build script finished"
-

--- a/ios_config.sh
+++ b/ios_config.sh
@@ -61,7 +61,8 @@ function setPlistValue {
 
 function getJsonKeyValue () {
   if [[ ${_RN_ROOT_EXISTS} ]]; then
-    ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$1'); puts output['expo']['extra']['react-native-google-mobile-ads']['$2']"
+    ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$1'); if output.dig('expo', 'extra', 'react-native-google-mobile-ads', '$2'); then puts output['expo']['extra']['react-native-google-mobile-ads']['$2']; else ''; end" || \
+    ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$1'); if output.dig('extra', 'react-native-google-mobile-ads', '$2'); then puts output['extra']['react-native-google-mobile-ads']['$2']; else ''; end"
   else
     echo ""
   fi;
@@ -115,11 +116,13 @@ if [[ ${_SEARCH_RESULT} ]]; then
     _JSON_OUTPUT_RAW=$(cat "${_SEARCH_RESULT}")
   fi;
 
-  _RN_ROOT_EXISTS=$(ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output['expo']['extra']['react-native-google-mobile-ads']" || echo '')
+  _RN_ROOT_EXISTS=$(ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); if output.dig('expo', 'extra', 'react-native-google-mobile-ads'); then puts true; else ''; end" || \
+                    ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); if output.dig('extra', 'react-native-google-mobile-ads'); then puts true; else ''; end" || echo '')
 
   if [[ ${_RN_ROOT_EXISTS} ]]; then
     if ! python3 --version >/dev/null 2>&1; then echo "python3 not found, app.json file processing error." && exit 1; fi
-    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64;print(base64.b64encode(bytes(json.dumps(json.loads(open('"'${_SEARCH_RESULT}'"', '"'rb'"').read())['expo']['extra']['react-native-google-mobile-ads']), '"'utf-8'"')).decode())' || echo "e30=")
+    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64; data=json.loads(open('"'${_SEARCH_RESULT}'"', '"'rb'"').read()); output=data; key_path=["expo", "extra", "react-native-google-mobile-ads"]; for key in key_path: output=output.get(key, {}); print(base64.b64encode(bytes(json.dumps(output), '"'utf-8'"')).decode())' || \
+                          python3 -c 'import json,sys,base64; data=json.loads(open('"'${_SEARCH_RESULT}'"', '"'rb'"').read()); output=data; key_path=["extra", "react-native-google-mobile-ads"]; for key in key_path: output=output.get(key, {}); print(base64.b64encode(bytes(json.dumps(output), '"'utf-8'"')).decode())' || echo "e30=")
   fi
 
   _PLIST_ENTRY_KEYS+=("google_mobile_ads_json_raw")


### PR DESCRIPTION
### Description
This PR tries to fix https://github.com/invertase/react-native-google-mobile-ads/issues/581. All the description of this problem is defined there, but, basically, since Expo SDK 51, it won't work if we try to get the `react-native-google-mobile-ads` key from the root of `app.json`. We need to get it from `root.extra` (thus, we need to change this documentation as well)

Please don't kill me... I have no idea what I am doing in that file (it was actually 100% gpt-4o).

The behavior implemented is this:
First, tries to find the `react-native-google-mobile-ads` key inside `root > expo > extra`, then, if it doesn't find it, it tries in `root > extra` (because Expo Cli may merge it soon).

### Pending stuff

We'll need to also change the documentation of this library, asking the users to put `react-native-google-mobile-ads` inside `extra`, instead of directly inside the root.

### Related issues

Fixes #581 

### Release Summary

Breaking: Move the `react-native-google-mobile-ads` key in `app.json` from `root` to `root.extra`

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No

### Test Plan

I'm not sure if this works. I'm proposing this PR as a first initial version

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
