### PR TITLE
chore: remove redundant app.config.js support

### DIFF
--- a/android/app-json.gradle
+++ b/android/app-json.gradle
@@ -1,67 +1,30 @@
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
-String[] fileNames = ["app.json", "app.config.js"]
-String fileName = null
+String fileName = "app.json"
 String jsonRoot = "react-native-google-mobile-ads"
 String jsonRaw = "GOOGLE_MOBILE_ADS_JSON_RAW"
 
-File configFile = null
+File jsonFile = null
 File parentDir = rootProject.projectDir
 
 for (int i = 0; i <= 3; i++) {
   if (parentDir == null) break
   parentDir = parentDir.parentFile
   if (parentDir != null) {
-    configFile = new File(parentDir, fileNames[0])
-    if (configFile.exists()) {
-      fileName = fileNames[0]
-      break
-    }
-    else {
-      configFile = new File(parentDir, fileNames[1])
-      if (configFile.exists()) {
-        fileName = fileNames[0]
-        break
-      }
-    }
+    jsonFile = new File(parentDir, fileName)
+    if (jsonFile.exists()) break
   }
 }
 
-if (configFile != null && configFile.exists()) {
-  rootProject.logger.info ":${project.name} ${fileName} found at ${configFile.toString()}"
+if (jsonFile != null && jsonFile.exists()) {
+  rootProject.logger.info ":${project.name} ${fileName} found at ${jsonFile.toString()}"
   Object json = null
 
   try {
-    // On windows, we need to escape path separators in the path before exec'ing shell
-    def configFileAbsolutePath = configFile.absolutePath
-    if (System.properties['os.name'].toLowerCase().contains('windows')) {
-        configFileAbsolutePath = configFileAbsolutePath.replace("\\", "\\\\")
-    }
-    // rootProject.logger.warn "have a path of ${configFileAbsolutePath}"
-
-    // The config may be either in Expo javascript (app.config.js) or JSON (app.json)
-    // If it is configured in Expo javascript, requiring it will generate a config
-    // If it is configured in JSON, requiring it will also generate the config
-    // So, use node to pull in the config file to get us a JSON string for either case
-    def configOutput = new StringBuffer();
-    def configReadProc = [
-      "node",
-      "-e",
-      "console.log(JSON.stringify(require('${configFileAbsolutePath}')));"
-    ]
-    .execute(null, projectDir)
-    configReadProc.waitForProcessOutput(configOutput, System.err)
-    configOutput = configOutput.toString().trim()
-    // rootProject.logger.warn "got configOutput of ${configOutput.toString()}"
-
-    if (configOutput && !configOutput.isEmpty()) {
-      json = new JsonSlurper().parseText(configOutput)
-    } else {
-      throw new Exception(":${project.name} received empty output while parsing ${configFile} found at ${configFile.toString()}.")
-    }
+    json = new JsonSlurper().parseText(jsonFile.text)
   } catch (Exception ignored) {
-    rootProject.logger.warn ":${project.name} failed to parse ${configFile} found at ${configFile.toString()}."
+    rootProject.logger.warn ":${project.name} failed to parse ${fileName} found at ${jsonFile.toString()}."
     rootProject.logger.warn ignored.toString()
   }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,7 +92,7 @@ if (!appJSONGoogleMobileAdsAppIDString && !isExpoProject) {
   println "\n\n\n"
   println "**************************************************************************************************************"
   println "\n\n\n"
-  println "ERROR: react-native-google-mobile-ads requires an 'android_app_id' property inside a 'react-native-google-mobile-ads' key in your app.json or app.config.js."
+  println "ERROR: react-native-google-mobile-ads requires an 'android_app_id' property inside a 'react-native-google-mobile-ads' key in your app.json."
   println "  No android_app_id property was found in this location. The native Google Mobile Ads SDK will crash on startup without it."
   println "\n\n\n"
   println "**************************************************************************************************************"

--- a/ios_config.sh
+++ b/ios_config.sh
@@ -28,13 +28,6 @@
 
 set -e
 
-if [[ -f "$PODS_ROOT/../.xcode.env" ]]; then
-  source "$PODS_ROOT/../.xcode.env"
-fi
-if [[ -f "$PODS_ROOT/../.xcode.env.local" ]]; then
-  source "$PODS_ROOT/../.xcode.env.local"
-fi
-
 _MAX_LOOKUPS=2;
 _SEARCH_RESULT=''
 _RN_ROOT_EXISTS=''
@@ -42,13 +35,11 @@ _CURRENT_LOOKUPS=1
 _PROJECT_ABBREVIATION="RNGoogleMobileAds"
 _JSON_ROOT="'react-native-google-mobile-ads'"
 _JSON_FILE_NAME='app.json'
-_JS_APP_CONFIG_FILE_NAME='app.config.js'
 _JSON_OUTPUT_BASE64='e30=' # { }
 _CURRENT_SEARCH_DIR=${PROJECT_DIR}
 _PLIST_BUDDY=/usr/libexec/PlistBuddy
 _TARGET_PLIST="${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}"
 _DSYM_PLIST="${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist"
-_IS_CONFIG_JS=false
 _PACKAGE_JSON_NAME='package.json'
 
 # plist arrays
@@ -87,26 +78,13 @@ fi;
 
 while true; do
   _CURRENT_SEARCH_DIR=$(dirname "$_CURRENT_SEARCH_DIR")
-
-  if [[ "$_CURRENT_SEARCH_DIR" == "/" ]] || [[ ${_CURRENT_LOOKUPS} -gt ${_MAX_LOOKUPS} ]]; then
+  if [[ "$_CURRENT_SEARCH_DIR" == "/" ]] || [[ ${_CURRENT_LOOKUPS} -gt ${_MAX_LOOKUPS} ]]; then break; fi;
+  echo "info:      ($_CURRENT_LOOKUPS of $_MAX_LOOKUPS) Searching in '$_CURRENT_SEARCH_DIR' for a ${_JSON_FILE_NAME} file."
+  _SEARCH_RESULT=$(find "$_CURRENT_SEARCH_DIR" -maxdepth 2 -name ${_JSON_FILE_NAME} -print | /usr/bin/head -n 1)
+  if [[ ${_SEARCH_RESULT} ]]; then
+    echo "info:      ${_JSON_FILE_NAME} found at $_SEARCH_RESULT"
     break;
   fi;
-
-  echo "info:      ($_CURRENT_LOOKUPS of $_MAX_LOOKUPS) Searching in '$_CURRENT_SEARCH_DIR' for a ${_JSON_FILE_NAME}/${_JS_APP_CONFIG_FILE_NAME} file."
-
-  _SEARCH_RESULT=$(find "$_CURRENT_SEARCH_DIR" -maxdepth 2 '(' -name ${_JSON_FILE_NAME} -o -name ${_JS_APP_CONFIG_FILE_NAME} ')' -print | /usr/bin/head -n 1)
-
-  if [[ "$(basename ${_SEARCH_RESULT})" = "${_JS_APP_CONFIG_FILE_NAME}" ]]; then
-    _IS_CONFIG_JS=true
-    echo "info:      ${_JS_APP_CONFIG_FILE_NAME} found at $_SEARCH_RESULT"
-    break;
-  fi;
-
-  if [[ "$(basename ${_SEARCH_RESULT})" = "${_JSON_FILE_NAME}" ]]; then
-    echo "info:      ${_JSON_FILE_NAME} found at ${_SEARCH_RESULT}"
-    break;
-  fi;
-
   _CURRENT_LOOKUPS=$((_CURRENT_LOOKUPS+1))
 done
 
@@ -120,12 +98,7 @@ if [[ ${_IS_PROJECT_USING_EXPO} == "true" ]]; then
 fi
 
 if [[ ${_SEARCH_RESULT} ]]; then
-  if [[ ${_IS_CONFIG_JS} == "true" ]]; then
-    _JSON_OUTPUT_RAW=$("${NODE_BINARY}" -e "console.log(JSON.stringify(require('${_SEARCH_RESULT}')));")
-  else
-    _JSON_OUTPUT_RAW=$(cat "${_SEARCH_RESULT}")
-  fi;
-
+  _JSON_OUTPUT_RAW=$(cat "${_SEARCH_RESULT}")
   _RN_ROOT_EXISTS=$(ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output[$_JSON_ROOT]" || echo '')
 
   if [[ ${_RN_ROOT_EXISTS} ]]; then
@@ -225,4 +198,3 @@ for plist in "${_TARGET_PLIST}" "${_DSYM_PLIST}" ; do
 done
 
 echo "info: <- ${_PROJECT_ABBREVIATION} build script finished"
-


### PR DESCRIPTION
### Description

This PR removes the redundant and deprecated handling of `app.config.js` files from the `ios_config.sh` and `build.gradle` scripts.

Now that `app.config.js` support is handled by the Expo config plugin, the `ios_config.sh` and `build.gradle` scripts no longer need to consider `app.config.js` at all. Parts of the code added in #517 can be removed again to make the scripts easier to maintain. That's exactly what this PR does. It's simply reverting all changes to the relevant files from said PR. I double checked that this does only revert the `app.config.js` support and nothing else (e.g. fixes or other refactorings).

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Ran our tests
- Made sure the example app still works