### PR TITLE
docs(ads-not-showing): Added info section about applicationId related issues to "Common reasons for ads not showing" 

### DIFF
--- a/docs/common-reasons-for-ads-not-showing.mdx
+++ b/docs/common-reasons-for-ads-not-showing.mdx
@@ -28,6 +28,19 @@ If you set up an app-ads.txt file for your app, you need to also include this li
 
 Alternatively, you can enable test devices and use your own ad unit IDs instead.
 
+### Check Your ApplicationId
+
+If you initiated your project with `react-native init`, the auto-generated `applicationId` might not fulfill the required structure or uniqueness needed for AdMob integration. This can lead to issues where the request was succesfull but no ads are shown. Here are common reasons and fixes related to `applicationId` issues:
+
+- **Non-unique ApplicationId**: The default `applicationId` may clash with existing apps, especially if you haven't customized it. AdMob requires a unique identifier for each app to correctly manage ad requests and revenue.
+
+- **Improperly Structured ApplicationId**: The `applicationId` should generally follow Java package name conventions, such as `com.companyname.appname`. It must start with a letter, and can only include letters (a-z, A-Z), numbers (0-9), and underscores (_). 
+
+Google documentation: [Configure the app module](https://developer.android.com/build/configure-app-module?hl=de)
+
+**Important**:  If you change the application ID of an already published app, Google Play Store treats the upload as a completely different app!
+
+
 ### Enable test devices
 
 If you want to do more rigorous testing with production-looking ads, configure your device as a test device and use your own ad unit IDs that you've created in the AdMob UI.


### PR DESCRIPTION
### Description

During the setup and initialization of a new React Native project, especially when using npx react-native init ProjectName, the autogenerated package name may not always be unique or suitable for production environments or even for developing. This can lead to issues, particularly when integrating with services like Google AdMob, where a unique package name is mandatory to avoid conflicts and operational issues.

This can lead to issues where the request was succesfull but no ads even test ads will be delivered.

### Related issues

#607 

### Release Summary


### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan


---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
