### PR TITLE
docs: add framework tabs and nav sections

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,5 +1,6 @@
 {
   "name": "React Native Google Mobile Ads",
+  "logo": "https://raw.githubusercontent.com/invertase/react-native-google-mobile-ads/main/docs/img/logo_admob_192px.svg",
   "twitter": "invertaseio",
   "sidebar": [
     [

--- a/docs.json
+++ b/docs.json
@@ -2,14 +2,29 @@
   "name": "React Native Google Mobile Ads",
   "twitter": "invertaseio",
   "sidebar": [
-    ["Installation", "/"],
-    ["Displaying Ads", "/displaying-ads"],
-    ["Displaying Ads via Hook", "/displaying-ads-hook"],
-    ["European User Consent", "/european-user-consent"],
-    ["Ad Inspector", "/ad-inspector"],
-    ["Impression-level ad revenue", "/impression-level-ad-revenue"],
-    ["Common Reasons For Ads Not Showing", "/common-reasons-for-ads-not-showing"],
-    ["Migrating to v5", "/migrating-to-v5"],
-    ["Migrating to v6", "/migrating-to-v6"]
+    [
+      "Getting Started",
+      [
+        ["Installation", "/"],
+        ["Displaying Ads", "/displaying-ads"],
+        ["Common Reasons For Ads Not Showing", "/common-reasons-for-ads-not-showing"]
+      ]
+    ],
+    [
+      "Advanced Usage",
+      [
+        ["Displaying Ads via Hook", "/displaying-ads-hook"],
+        ["European User Consent", "/european-user-consent"],
+        ["Ad Inspector", "/ad-inspector"],
+        ["Impression-level ad revenue", "/impression-level-ad-revenue"]
+      ]
+    ],
+    [
+      "Migration Guides",
+      [
+        ["Migrating to v5", "/migrating-to-v5"],
+        ["Migrating to v6", "/migrating-to-v6"]
+      ]
+    ]
   ]
 }

--- a/docs.json
+++ b/docs.json
@@ -6,7 +6,7 @@
     [
       "Getting Started",
       [
-        ["Installation", "/"],
+        ["Getting Started", "/"],
         ["Displaying Ads", "/displaying-ads"],
         ["Common Reasons For Ads Not Showing", "/common-reasons-for-ads-not-showing"]
       ]

--- a/docs/ad-inspector.mdx
+++ b/docs/ad-inspector.mdx
@@ -2,7 +2,7 @@
 
 The debug menu is a tool that allows you to test and debug your app's ad experience. It can be used to:
 
-```
+```js
 await mobileAds().openDebugMenu(AD_UNIT_ID);
 ````
 

--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -18,16 +18,21 @@ ad requests to Google serve personalized ads, with ad selection based on the use
 
 ## Handling consent
 
-To setup and configure ads consent collection, first of all:
+To setup and configure ads consent collection, start by enabling and configuring GDPR and IDFA messaging in the [Privacy & messaging section of AdMob's Web Console](https://apps.admob.com/v2/privacymessaging).
 
-- Enable and configure GDPR and IDFA messaging in the [Privacy & messaging section of AdMob's Web Console](https://apps.admob.com/v2/privacymessaging).
+<Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
+<TabItem value="bare">
 
-- For Android, add the following rule into
-  `android/app/proguard-rules.pro`:
-  ```
-  -keep class com.google.android.gms.internal.consent_sdk.** { *; }
-  ```
-- For Expo users, add extraProguardRules property to `app.json` file following this guide [Expo](https://docs.expo.dev/versions/latest/sdk/build-properties/#pluginconfigtypeandroid):
+For Android, add the following rule into `android/app/proguard-rules.pro`:
+
+```
+-keep class com.google.android.gms.internal.consent_sdk.** { *; }
+```
+
+</TabItem>
+<TabItem value="expo">
+
+Add the `extraProguardRules` property to `app.json` file as described in the [Expo documentation](https://docs.expo.dev/versions/latest/sdk/build-properties/#pluginconfigtypeandroid):
 
 ```json
 {
@@ -48,14 +53,21 @@ To setup and configure ads consent collection, first of all:
 
 You'll need to generate a new development build before using it.
 
+</TabItem>
+</Tabs>
+
 ### Delaying app measurement
 
 By default, the Google Mobile Ads SDK initializes app measurement and begins sending user-level event data to Google immediately when the app starts.
 If your app will be used by users within the EEA, it is important you prevent app measurement until your first ad has been requested (after consent).
 
+<Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
+<TabItem value="bare">
+
 Within your projects `app.json` file, set the `delay_app_measurement_init` to `true` to delay app measurement:
 
 ```json
+// <project-root>/app.json
 {
   "react-native-google-mobile-ads": {
     "android_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
@@ -65,15 +77,33 @@ Within your projects `app.json` file, set the `delay_app_measurement_init` to `t
 }
 ```
 
-Once set, rebuild your application:
+</TabItem>
+<TabItem value="expo">
 
-```bash
-# For iOS
-npx react-native run-ios
+Within your projects `app.json` file, set the `delayAppMeasurementInit` to `true` to delay app measurement:
 
-# For Android
-npx react-native run-android
+```json
+// <project-root>/app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "react-native-google-mobile-ads",
+        {
+          "androidAppId": "ca-app-pub-xxxxxxxx~xxxxxxxx",
+          "iosAppId": "ca-app-pub-xxxxxxxx~xxxxxxxx",
+          "delayAppMeasurementInit": true
+        }
+      ]
+    ]
+  }
+}
 ```
+
+</TabItem>
+</Tabs>
+
+Once set, rebuild your application.
 
 ### App Tracking Transparency
 
@@ -81,7 +111,8 @@ If you configure an [ATT message](https://support.google.com/admob/answer/101153
 This will also show an IDFA explainer message. If you don't want to show an explainer message you can show the ATT alert [manually](https://docs.page/invertase/react-native-google-mobile-ads#app-tracking-transparency-ios).
 Also, within your projects `app.json` file, you have to provide a user tracking usage description (once set, rebuild your application):
 
-#### For React Native projects (without Expo)
+<Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
+<TabItem value="bare">
 
 ```json
 // <project-root>/app.json
@@ -94,7 +125,8 @@ Also, within your projects `app.json` file, you have to provide a user tracking 
 }
 ```
 
-#### For Expo projects
+</TabItem>
+<TabItem value="expo">
 
 ```json
 // <project-root>/app.json
@@ -113,6 +145,9 @@ Also, within your projects `app.json` file, you have to provide a user tracking 
   }
 }
 ```
+
+</TabItem>
+</Tabs>
 
 ### Requesting consent information
 
@@ -140,7 +175,7 @@ the the actual user consent**. It simply indicates if you now have a consent res
 (_i.e._ if user consent is **required**, the form has been presented, and user has
 **denied** the consent, the status returned by this method will be `OBTAINED`,
 and not `REQUIRED` as some may expect). To check the actual consent status
-see [Inspecting consent choices] below.
+see [Inspecting consent choices](/european-user-consent/#inspecting-consent-choices) below.
 
 ### Gathering user consent
 
@@ -280,7 +315,3 @@ AdsConsent.reset();
 In case of troubles, double-check the original documentation for underlying
 UMP SDK for [Android](https://developers.google.com/admob/ump/android/quick-start) /
 [iOS](https://developers.google.com/admob/ump/ios/quick-start).
-
-<!-- links -->
-
-[inspecting consent choices]: #inspecting-consent-choices

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,4 +1,18 @@
-# Installation
+# Getting Started
+
+The AdMob module allows you to display adverts to your users. All adverts are served over the Google AdMob network, meaning
+a [Google AdMob account](https://apps.admob.com) is required.
+
+<YouTube id="9qCxo0D-Sak" />
+
+The module supports four types of Ads:
+
+1. Full screen [App Open Ads](/displaying-ads#app-open-ads).
+2. Full screen [Interstitial Ads](/displaying-ads#interstitial-ads).
+3. Full screen [Rewarded Ads](/displaying-ads#rewarded-ads).
+4. Component based [Banner Ads](/displaying-ads#banner-ads).
+
+## Installation
 
 ```bash
 # Install the admob module
@@ -7,7 +21,7 @@ yarn add react-native-google-mobile-ads
 
 > On Android, before releasing your app, you must select _Yes, my app contains ads_ in the Google Play Store, Policy, App content, Manage under Ads.
 
-## Optionally configure iOS static frameworks
+### Optionally configure iOS static frameworks
 
 On iOS if you need to use static frameworks (that is, `use_frameworks! :linkage => :static` in your `Podfile`) you must add the variable `$RNGoogleMobileAdsAsStaticFramework = true` to the targets in your `Podfile`. You may need this if you use this module in combination with react-native-firebase v15 and higher since it requires `use_frameworks!`.
 
@@ -51,32 +65,6 @@ To do so [follow the official `expo-build-properties` installation instructions]
   }
 }
 ```
-
-## What does it do
-
-The AdMob module allows you to display adverts to your users. All adverts are served over the Google AdMob network, meaning
-a [Google AdMob account](https://apps.admob.com) is required.
-
-<YouTube id="9qCxo0D-Sak" />
-
-The module supports four types of Ads:
-
-1. Full screen [App Open Ads](/displaying-ads#app-open-ads).
-2. Full screen [Interstitial Ads](/displaying-ads#interstitial-ads).
-3. Full screen [Rewarded Ads](/displaying-ads#rewarded-ads).
-4. Component based [Banner Ads](/displaying-ads#banner-ads).
-
-## Getting Started
-
-A number of steps must be taken and considered before you start serving adverts to your users:
-
-- [Installation](#installation)
-- [Getting Started](#getting-started)
-  - [Setting up Google AdMob](#setting-up-google-admob)
-  - [Configure outbound requests](#configure-outbound-requests)
-  - [European User Consent](#european-user-consent)
-  - [Test ads](#test-ads)
-- [Next Steps](#next-steps)
 
 ### Setting up Google AdMob
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,23 +14,45 @@ The module supports four types of Ads:
 
 ## Installation
 
+<Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
+<TabItem value="bare">
+
 ```bash
 # Install the admob module
-yarn add react-native-google-mobile-ads
+npm install react-native-google-mobile-ads
 ```
+
+</TabItem>
+<TabItem value="expo">
+
+```bash
+# Install the admob module and config plugin
+npx expo install react-native-google-mobile-ads
+```
+
+</TabItem>
+</Tabs>
 
 > On Android, before releasing your app, you must select _Yes, my app contains ads_ in the Google Play Store, Policy, App content, Manage under Ads.
 
 ### Optionally configure iOS static frameworks
 
-On iOS if you need to use static frameworks (that is, `use_frameworks! :linkage => :static` in your `Podfile`) you must add the variable `$RNGoogleMobileAdsAsStaticFramework = true` to the targets in your `Podfile`. You may need this if you use this module in combination with react-native-firebase v15 and higher since it requires `use_frameworks!`.
+Follow these steps on iOS if you need to use static frameworks (that is, `use_frameworks! :linkage => :static` in your `Podfile`).
+You may need this if you use this module in combination with `react-native-firebase` v15 and higher since it requires `use_frameworks!`.
+
+<Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
+<TabItem value="bare">
+
+To enable static frameworks, you must add the variable `$RNGoogleMobileAdsAsStaticFramework = true` to the targets in your `Podfile`.
+
+</TabItem>
+<TabItem value="expo">
 
 Expo users may enable static frameworks by using the `expo-build-properties` plugin.
-To do so [follow the official `expo-build-properties` installation instructions](https://docs.expo.dev/versions/latest/sdk/build-properties/) and merge the following code into your `app.json` or `app.config.js` file:
-
-#### app.json
+To do so [follow the official `expo-build-properties` installation instructions](https://docs.expo.dev/versions/latest/sdk/build-properties/) and merge the following code into your `app.json` file:
 
 ```json
+// <project-root>/app.json
 {
   "expo": {
     "plugins": [
@@ -47,24 +69,8 @@ To do so [follow the official `expo-build-properties` installation instructions]
 }
 ```
 
-#### app.config.js
-
-```js
-{
-  expo: {
-    plugins: [
-      [
-        'expo-build-properties',
-        {
-          ios: {
-            useFrameworks: 'static',
-          },
-        },
-      ],
-    ];
-  }
-}
-```
+</TabItem>
+</Tabs>
 
 ### Setting up Google AdMob
 
@@ -72,7 +78,7 @@ Before you are able to display ads to your users, you must have a [Google AdMob 
 "Apps" menu item, create or choose an existing Android/iOS app. Each app platform exposes a unique account ID which needs to
 be added to the project.
 
-> Attempting to build your app without a valid App ID in `app.json` or `app.config.js` will cause the app to crash on start or fail to build.
+> Attempting to build your app without a valid App ID in `app.json` will cause the app to crash on start or fail to build.
 
 Under the "App settings" menu item, you can find the "App ID":
 
@@ -82,7 +88,9 @@ The app IDs for Android and iOS need to be inserted into your apps native code.
 For React Native projects without Expo, you can add the app IDs to the `app.json` file.
 For Expo projects, we provide an [Expo config plugin](https://docs.expo.dev/config-plugins/introduction/).
 
-#### For React Native projects (without Expo)
+
+<Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
+<TabItem value="bare">
 
 ```json
 // <project-root>/app.json
@@ -105,11 +113,10 @@ npx react-native run-ios
 npx react-native run-android
 ```
 
-#### For Expo projects
+</TabItem>
+<TabItem value="expo">
 
-> ⚠️ This module contains custom native code which is NOT supported by Expo Go
-
-This library contains an Expo config plugin which you must add to your `app.json`, `app.config.js` or `app.config.ts` file.
+This library contains an Expo config plugin which you must add to your `app.json` file.
 For these changes to take effect, your must rebuild your project's native code and install the new build on your device.
 
 ```json
@@ -128,6 +135,8 @@ For these changes to take effect, your must rebuild your project's native code a
   }
 }
 ```
+
+> ⚠️ This module contains custom native code which is NOT supported by Expo Go
 
 If you're using Expo without EAS, run the following commands:
 
@@ -150,6 +159,9 @@ npx eas-cli build --profile development
 # For local builds
 npx eas-cli build --profile development --local
 ```
+
+</TabItem>
+</Tabs>
 
 ### Configure outbound requests
 
@@ -211,7 +223,8 @@ The Google Mobile Ads SDK supports conversion tracking using Apple's SKAdNetwork
 Within your projects `app.json` file, add the advised [SKAdNetwork identifiers](https://developers.google.com/ad-manager/mobile-ads-sdk/ios/3p-skadnetworks).
 Note that these identifiers are subject to change and should be updated regularly.
 
-#### For React Native projects (without Expo)
+<Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
+<TabItem value="bare">
 
 ```json
 // <project-root>/app.json
@@ -274,7 +287,8 @@ Note that these identifiers are subject to change and should be updated regularl
 }
 ```
 
-#### For Expo projects
+</TabItem>
+<TabItem value="expo">
 
 ```json
 // <project-root>/app.json
@@ -287,8 +301,55 @@ Note that these identifiers are subject to change and should be updated regularl
           "androidAppId": "ca-app-pub-xxxxxxxx~xxxxxxxx",
           "iosAppId": "ca-app-pub-xxxxxxxx~xxxxxxxx",
           "skAdNetworkItems": [
-            // list of network ids removed to avoid duplication
-            // please refer to the list in the `app.jaon` configuration section above
+            "cstr6suwn9.skadnetwork",
+            "4fzdc2evr5.skadnetwork",
+            "4pfyvq9l8r.skadnetwork",
+            "2fnua5tdw4.skadnetwork",
+            "ydx93a7ass.skadnetwork",
+            "5a6flpkh64.skadnetwork",
+            "p78axxw29g.skadnetwork",
+            "v72qych5uu.skadnetwork",
+            "ludvb6z3bs.skadnetwork",
+            "cp8zw746q7.skadnetwork",
+            "3sh42y64q3.skadnetwork",
+            "c6k4g5qg8m.skadnetwork",
+            "s39g8k73mm.skadnetwork",
+            "3qy4746246.skadnetwork",
+            "f38h382jlk.skadnetwork",
+            "hs6bdukanm.skadnetwork",
+            "v4nxqhlyqp.skadnetwork",
+            "wzmmz9fp6w.skadnetwork",
+            "yclnxrl5pm.skadnetwork",
+            "t38b2kh725.skadnetwork",
+            "7ug5zh24hu.skadnetwork",
+            "gta9lk7p23.skadnetwork",
+            "vutu7akeur.skadnetwork",
+            "y5ghdn5j9k.skadnetwork",
+            "n6fk4nfna4.skadnetwork",
+            "v9wttpbfk9.skadnetwork",
+            "n38lu8286q.skadnetwork",
+            "47vhws6wlr.skadnetwork",
+            "kbd757ywx3.skadnetwork",
+            "9t245vhmpl.skadnetwork",
+            "eh6m2bh4zr.skadnetwork",
+            "a2p9lx4jpn.skadnetwork",
+            "22mmun2rn5.skadnetwork",
+            "4468km3ulz.skadnetwork",
+            "2u9pt9hc89.skadnetwork",
+            "8s468mfl3y.skadnetwork",
+            "klf5c3l5u5.skadnetwork",
+            "ppxm28t8ap.skadnetwork",
+            "ecpz2srf59.skadnetwork",
+            "uw77j35x4d.skadnetwork",
+            "pwa73g5rt2.skadnetwork",
+            "mlmmfzh3r3.skadnetwork",
+            "578prtvx9j.skadnetwork",
+            "4dzt52r2t5.skadnetwork",
+            "e5fvkxwrpn.skadnetwork",
+            "8c4e2ghe7u.skadnetwork",
+            "zq492l623r.skadnetwork",
+            "3rd42ekr43.skadnetwork",
+            "3qcr597p9d.skadnetwork"
           ],
         }
       ]
@@ -297,12 +358,16 @@ Note that these identifiers are subject to change and should be updated regularl
 }
 ```
 
+</TabItem>
+</Tabs>
+
 ### App Tracking Transparency (iOS)
 
 Apple requires apps to display the App Tracking Transparency authorization request for accessing the IDFA (leaving the choice to the user, whether to use personalized or non-personalized ads).
 Within your projects `app.json` file, you have to provide a user tracking usage description:
 
-#### For React Native projects (without Expo)
+<Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
+<TabItem value="bare">
 
 ```json
 // <project-root>/app.json
@@ -315,7 +380,8 @@ Within your projects `app.json` file, you have to provide a user tracking usage 
 }
 ```
 
-#### For Expo projects
+</TabItem>
+<TabItem value="expo">
 
 ```json
 // <project-root>/app.json
@@ -334,6 +400,9 @@ Within your projects `app.json` file, you have to provide a user tracking usage 
   }
 }
 ```
+
+</TabItem>
+</Tabs>
 
 #### Requesting App Tracking Transparency authorization
 


### PR DESCRIPTION
### Description

I spend some time putting Bare RN and Expo specific parts of the documentation in side-by-side tabs. Looks like this:

![image](https://github.com/user-attachments/assets/80525158-a256-4408-940a-5be64cb708ad)

This is a docs.page feature which I quite like. I made sure all tabs are synchronized, meaning if you choose Expo for example, all tabs will switch to Expo. Default is React Native.

I also fixed the mess at the beginning of the startpage. It always confused me that we had the following sections in that order: Installation; Optional static frameworks; What does the package do; Actual Installation Instructions.
Instead, the "What does the package do" is now first and then followed by all installation instructions. Note that for Expo I recommended `npx expo install react-native-google-mobile-ads`. This does not only install the dependency, but also adds the expo config plugin to the `app.json` file.

While reading the docs.page docs, I also noticed we can use sections in the navigation sidebar. So I did that as well. I put all the essentials first needed to get some ads to show. Next there is an advanced usage section and lastly a section for our migration guides. (if we get issues regarding to v14 migration, I will add a guide for that).

![image](https://github.com/user-attachments/assets/c348c89b-bde5-4e48-9d42-a9417838bedb)

Also did some small fixes here and there and added embedded the logo from the readme in the sites header.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
I previewed the changes in my fork using docs.page. [Take a look](https://docs.page/DoctorJohn/react-native-google-ads) (force refresh the page a few times with F5 if you feel like it's outdated).
