### PR TITLE
docs: clarify severity of callouts

### DIFF
--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -20,9 +20,11 @@ export default function App() {
 }
 ```
 
-> The `adUnitid` parameter can also be used to manage creation and destruction of an ad instance.
-> If `adUnitid` is set or changed, new ad instance will be created and previous ad instance will be destroyed if exists.
-> If `adUnitid` is set to `null`, no ad instance will be created and previous ad instance will be destroyed if exists.
+<Info>
+The `adUnitid` parameter can also be used to manage creation and destruction of an ad instance.
+If `adUnitid` is set or changed, new ad instance will be created and previous ad instance will be destroyed if exists.
+If `adUnitid` is set to `null`, no ad instance will be created and previous ad instance will be destroyed if exists.
+</Info>
 
 The second argument is an additional optional request options object to be sent whilst loading an advert, such as keywords & location.
 Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](/reference/admob/requestoptions)
@@ -92,8 +94,10 @@ Return values of the hook are:
 | load           | Function                           | Start loading the advert with the provided RequestOptions.                                                         |
 | show           | Function                           | Show the loaded advert to the user.                                                                                |
 
-> Note that `isOpened` value remains `true` even after the ad is closed.
-> The value changes to `false` when ad is initialized via calling `load()`.
-> To determine whether the ad is currently showing, use `isShowing` value.
+<Info>
+Note that `isOpened` value remains `true` even after the ad is closed.
+The value changes to `false` when ad is initialized via calling `load()`.
+To determine whether the ad is currently showing, use `isShowing` value.
+</Info>
 
 [Impression-level ad revenue]: /impression-level-ad-revenue

--- a/docs/displaying-ads.mdx
+++ b/docs/displaying-ads.mdx
@@ -423,7 +423,9 @@ function App() {
 The `size` prop takes a [`BannerAdSize`](/reference/admob/banneradsize) type, and once the advert is available, will
 fill the space for the chosen size.
 
-> If no inventory for the size specified is available, an error will be thrown via `onAdFailedToLoad`!
+<Info>
+If no inventory for the size specified is available, an error will be thrown via `onAdFailedToLoad`!
+</Info>
 
 The `requestOptions` prop is additional optional request options object to be sent whilst loading an advert, such as keywords & location.
 Setting additional request options helps AdMob choose better tailored ads from the network. View the [`RequestOptions`](/reference/admob/requestoptions)

--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -14,7 +14,9 @@ Android & iOS, and provides a single JavaScript interface for both platforms.
 Ads served by Google can be categorized as personalized or non-personalized, both requiring consent from users in the EEA. By default,
 ad requests to Google serve personalized ads, with ad selection based on the user's previously collected data. Users outside of the EEA do not require consent.
 
-> The `AdsConsent` helper only provides you with the tools for requesting consent, it is up to the developer to ensure the consent status is reflected throughout the app.
+<Info>
+The `AdsConsent` helper only provides you with the tools for requesting consent, it is up to the developer to ensure the consent status is reflected throughout the app.
+</Info>
 
 ## Handling consent
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -34,7 +34,7 @@ npx expo install react-native-google-mobile-ads
 </Tabs>
 
 <Info>
-On Android, before releasing your app, you must select _Yes, my app contains ads_ in the Google Play Store, Policy, App content, Manage under Ads.
+On Android, before releasing your app, you must select "Yes, my app contains ads" in the Google Play Console under "Policy and programmes" > "App content" > "Manage".
 </Info>
 
 ### Optionally configure iOS static frameworks

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -33,7 +33,9 @@ npx expo install react-native-google-mobile-ads
 </TabItem>
 </Tabs>
 
-> On Android, before releasing your app, you must select _Yes, my app contains ads_ in the Google Play Store, Policy, App content, Manage under Ads.
+<Info>
+On Android, before releasing your app, you must select _Yes, my app contains ads_ in the Google Play Store, Policy, App content, Manage under Ads.
+</Info>
 
 ### Optionally configure iOS static frameworks
 
@@ -78,7 +80,9 @@ Before you are able to display ads to your users, you must have a [Google AdMob 
 "Apps" menu item, create or choose an existing Android/iOS app. Each app platform exposes a unique account ID which needs to
 be added to the project.
 
-> Attempting to build your app without a valid App ID in `app.json` will cause the app to crash on start or fail to build.
+<Warning>
+Attempting to build your app without a valid App ID in `app.json` will cause the app to crash on start or fail to build.
+</Warning>
 
 Under the "App settings" menu item, you can find the "App ID":
 
@@ -136,7 +140,9 @@ For these changes to take effect, your must rebuild your project's native code a
 }
 ```
 
-> ⚠️ This module contains custom native code which is NOT supported by Expo Go
+<Warning>
+️ This module contains custom native code which is NOT supported by Expo Go
+</Warning>
 
 If you're using Expo without EAS, run the following commands:
 
@@ -202,8 +208,10 @@ To learn more about the request configuration settings, view the [`RequestConfig
 Before loading ads, have your app initialize the Google Mobile Ads SDK by calling `initialize` which initializes the SDK and returns a promise once initialization is complete (or after a 30-second timeout).
 This needs to be done only once, ideally at app launch.
 
-> ⚠️ **Warning:** Ads may be preloaded by the Mobile Ads SDK or mediation partner SDKs upon calling `initialize`.
-> If you need to obtain consent from users in the European Economic Area (EEA), set any request-specific flags (such as tagForChildDirectedTreatment), or otherwise take action before loading ads, ensure you do so before initializing the Mobile Ads SDK.
+<Warning>
+Ads may be preloaded by the Mobile Ads SDK or mediation partner SDKs upon calling `initialize`.
+If you need to obtain consent from users in the European Economic Area (EEA), set any request-specific flags (such as tagForChildDirectedTreatment), or otherwise take action before loading ads, ensure you do so before initializing the Mobile Ads SDK.
+</Warning>
 
 ```js
 import mobileAds from 'react-native-google-mobile-ads';


### PR DESCRIPTION
### Description

This PR replaces some blockquotes in the docs with docs.page callout components.

We often use blockquotes in the docs to give users warnings or hints, but also simply for quotes. Currently it's not obvious to the reader what the severity/importance of each blockquote is. This PR makes that more obvious by using "warning callouts" for warnings and "info callouts" for hints.

Warnings, for example, now look like this:

<details>
<summary>Show screenshot</summary>

![image](https://github.com/user-attachments/assets/6699e909-cfc6-4bbf-b11d-42aa37eea20f)

</details>

### Test Plan

Take a look at the docs.page preview for my branch: https://docs.page/DoctorJohn/react-native-google-ads~clarify-severity

:fire:  