### PR TITLE
fix: expo managed project detection

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,8 +74,7 @@ project.ext {
 
 apply from: file("./app-json.gradle")
 
-def rootPackageJson = PackageJson.getForProject(rootProject)
-def isExpoProject = rootPackageJson['dependencies'].containsKey('expo')
+def isManagedExpoProject = !rootProject.file("android").exists() && !rootProject.file("ios").exists()
 def appJSONGoogleMobileAdsAppIDString = ""
 def appJSONGoogleMobileAdsDelayAppMeasurementInitBool = false
 def appJSONGoogleMobileAdsOptimizeInitializationBool = true
@@ -88,7 +87,7 @@ if (rootProject.ext.has("googleMobileAdsJson")) {
   appJSONGoogleMobileAdsOptimizeAdLoadingBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("optimize_ad_loading", true)
 }
 
-if (!appJSONGoogleMobileAdsAppIDString && !isExpoProject) {
+if (!appJSONGoogleMobileAdsAppIDString && !isManagedExpoProject) {
   println "\n\n\n"
   println "**************************************************************************************************************"
   println "\n\n\n"

--- a/ios_config.sh
+++ b/ios_config.sh
@@ -88,12 +88,9 @@ while true; do
   _CURRENT_LOOKUPS=$((_CURRENT_LOOKUPS+1))
 done
 
-# Bail out if project is using Expo
-_PACKAGE_JSON_PATH=$(dirname "${_SEARCH_RESULT}")/${_PACKAGE_JSON_NAME}
-_IS_PROJECT_USING_EXPO=$(ruby -KU -e "require 'json'; package=JSON.parse(File.read('${_PACKAGE_JSON_PATH}')); puts package['dependencies'].key?('expo')")
-
-if [[ ${_IS_PROJECT_USING_EXPO} == "true" ]]; then
-  echo "info: Expo project detected, assume Expo Config Plugin is used."
+# Bail out if project is a managed Expo project:
+if [[ ! -d "${PROJECT_DIR}/ios" ]] && [[ ! -d "${PROJECT_DIR}/android" ]]; then
+  echo "info: Project does not contain an ios or android folder, assume it's a managed Expo project using our Expo Config Plugin."
   exit 0
 fi
 


### PR DESCRIPTION
### Description

This PR adjust the expo managed workflow detection to no longer yield false-positives for bare RN projects using expo modules.

### Related issues

- Fixes #614

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Successfully ran jest tests
- Successfully built and ran the bare test app
- Successfully built and ran EAS builds for android and ios