### PR TITLE
test: fix outdated and unused type tests

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src"],
+  "include": ["src", "type-test.ts"],
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",

--- a/type-test.ts
+++ b/type-test.ts
@@ -27,7 +27,7 @@ import mobileAds, {
   useRewardedAd,
   useRewardedInterstitialAd,
   useForeground,
-} from '.';
+} from './src';
 
 // static exports
 console.log(SDK_VERSION);

--- a/type-test.ts
+++ b/type-test.ts
@@ -1,115 +1,290 @@
 /* eslint-disable no-console */
-import * as googleMobileAds from 'react-native-google-mobile-ads';
+import mobileAds, {
+  SDK_VERSION,
+  MobileAds,
+  AdsConsentDebugGeography,
+  AdsConsentPurposes,
+  AdsConsentSpecialFeatures,
+  AdsConsentStatus,
+  AdsConsentPrivacyOptionsRequirementStatus,
+  MaxAdContentRating,
+  TestIds,
+  AdEventType,
+  BannerAdSize,
+  GAMBannerAdSize,
+  GAMAdEventType,
+  RewardedAdEventType,
+  AdsConsent,
+  AppOpenAd,
+  InterstitialAd,
+  RewardedAd,
+  RewardedInterstitialAd,
+  BannerAd,
+  GAMBannerAd,
+  GAMInterstitialAd,
+  useAppOpenAd,
+  useInterstitialAd,
+  useRewardedAd,
+  useRewardedInterstitialAd,
+  useForeground,
+} from '.';
 
-console.log(googleMobileAds.AdsConsentDebugGeography.DISABLED);
-console.log(googleMobileAds.AdsConsentDebugGeography.EEA);
-console.log(googleMobileAds.AdsConsentDebugGeography.NOT_EEA);
-console.log(googleMobileAds.AdsConsentDebugGeography.DISABLED);
-console.log(googleMobileAds.AdsConsentDebugGeography.EEA);
-console.log(googleMobileAds.AdsConsentDebugGeography.NOT_EEA);
+// static exports
+console.log(SDK_VERSION);
 
-console.log(googleMobileAds.AdsConsentStatus.UNKNOWN);
-console.log(googleMobileAds.AdsConsentStatus.REQUIRED);
-console.log(googleMobileAds.AdsConsentStatus.NOT_REQUIRED);
-console.log(googleMobileAds.AdsConsentStatus.OBTAINED);
-console.log(googleMobileAds.AdsConsentStatus.UNKNOWN);
-console.log(googleMobileAds.AdsConsentStatus.REQUIRED);
-console.log(googleMobileAds.AdsConsentStatus.NOT_REQUIRED);
-console.log(googleMobileAds.AdsConsentStatus.OBTAINED);
+// default export
+mobileAds()
+  .initialize()
+  .then(statuses => statuses);
+mobileAds().openAdInspector().then();
+mobileAds().openDebugMenu('foo');
+mobileAds().setAppMuted(false);
+mobileAds().setAppVolume(0.5);
+mobileAds().setRequestConfiguration({ maxAdContentRating: MaxAdContentRating.G }).then();
+mobileAds().subscribeToNativeModuleEvent('foo');
 
-console.log(googleMobileAds.MaxAdContentRating.G);
-console.log(googleMobileAds.MaxAdContentRating.MA);
-console.log(googleMobileAds.MaxAdContentRating.PG);
-console.log(googleMobileAds.MaxAdContentRating.T);
-console.log(googleMobileAds.MaxAdContentRating.G);
-console.log(googleMobileAds.MaxAdContentRating.MA);
-console.log(googleMobileAds.MaxAdContentRating.PG);
-console.log(googleMobileAds.MaxAdContentRating.T);
+// MobileAds
+MobileAds()
+  .initialize()
+  .then(statuses => statuses);
+MobileAds().openAdInspector().then();
+MobileAds().openDebugMenu('foo');
+MobileAds().setAppMuted(false);
+MobileAds().setAppVolume(0.5);
+MobileAds().setRequestConfiguration({ maxAdContentRating: MaxAdContentRating.G }).then();
+MobileAds().subscribeToNativeModuleEvent('foo');
 
-console.log(googleMobileAds.AdEventType.CLICKED);
-console.log(googleMobileAds.AdEventType.CLOSED);
-console.log(googleMobileAds.AdEventType.ERROR);
-console.log(googleMobileAds.AdEventType.LOADED);
-console.log(googleMobileAds.AdEventType.OPENED);
-console.log(googleMobileAds.AdEventType.CLICKED);
-console.log(googleMobileAds.AdEventType.CLOSED);
-console.log(googleMobileAds.AdEventType.ERROR);
-console.log(googleMobileAds.AdEventType.LOADED);
-console.log(googleMobileAds.AdEventType.OPENED);
+// AdsConsentDebugGeography
+console.log(AdsConsentDebugGeography.DISABLED);
+console.log(AdsConsentDebugGeography.EEA);
+console.log(AdsConsentDebugGeography.NOT_EEA);
 
-console.log(googleMobileAds.RewardedAdEventType.LOADED);
-console.log(googleMobileAds.RewardedAdEventType.EARNED_REWARD);
-console.log(googleMobileAds.RewardedAdEventType.LOADED);
-console.log(googleMobileAds.RewardedAdEventType.EARNED_REWARD);
+// AdsConsentPurposes
+console.log(AdsConsentPurposes.APPLY_MARKET_RESEARCH_TO_GENERATE_AUDIENCE_INSIGHTS);
+console.log(AdsConsentPurposes.CREATE_A_PERSONALISED_ADS_PROFILE);
+console.log(AdsConsentPurposes.CREATE_A_PERSONALISED_CONTENT_PROFILE);
+console.log(AdsConsentPurposes.DEVELOP_AND_IMPROVE_PRODUCTS);
+console.log(AdsConsentPurposes.MEASURE_AD_PERFORMANCE);
+console.log(AdsConsentPurposes.MEASURE_CONTENT_PERFORMANCE);
+console.log(AdsConsentPurposes.SELECT_BASIC_ADS);
+console.log(AdsConsentPurposes.SELECT_PERSONALISED_ADS);
+console.log(AdsConsentPurposes.SELECT_PERSONALISED_CONTENT);
+console.log(AdsConsentPurposes.STORE_AND_ACCESS_INFORMATION_ON_DEVICE);
 
-console.log(googleMobileAds.BannerAdSize.BANNER);
-console.log(googleMobileAds.BannerAdSize.FLUID);
-console.log(googleMobileAds.BannerAdSize.FULL_BANNER);
-console.log(googleMobileAds.BannerAd);
-console.log(googleMobileAds.BannerAdSize.BANNER);
-console.log(googleMobileAds.BannerAdSize.FLUID);
-console.log(googleMobileAds.BannerAdSize.FULL_BANNER);
+// AdsConsentSpecialFeatures
+console.log(AdsConsentSpecialFeatures.ACTIVELY_SCAN_DEVICE_CHARACTERISTICS_FOR_IDENTIFICATION);
+console.log(AdsConsentSpecialFeatures.USE_PRECISE_GEOLOCATION_DATA);
 
-console.log(googleMobileAds.TestIds.BANNER);
-console.log(googleMobileAds.TestIds.INTERSTITIAL);
-console.log(googleMobileAds.TestIds.REWARDED);
-console.log(googleMobileAds.TestIds.BANNER);
-console.log(googleMobileAds.TestIds.INTERSTITIAL);
-console.log(googleMobileAds.TestIds.REWARDED);
+// AdsConsentStatus
+console.log(AdsConsentStatus.UNKNOWN);
+console.log(AdsConsentStatus.REQUIRED);
+console.log(AdsConsentStatus.NOT_REQUIRED);
+console.log(AdsConsentStatus.OBTAINED);
+
+// AdsConsentPrivacyOptionsRequirementStatus
+console.log(AdsConsentPrivacyOptionsRequirementStatus.NOT_REQUIRED);
+console.log(AdsConsentPrivacyOptionsRequirementStatus.REQUIRED);
+console.log(AdsConsentPrivacyOptionsRequirementStatus.UNKNOWN);
+
+// MaxAdContentRating
+console.log(MaxAdContentRating.G);
+console.log(MaxAdContentRating.MA);
+console.log(MaxAdContentRating.PG);
+console.log(MaxAdContentRating.T);
+
+// TestIds
+console.log(TestIds.ADAPTIVE_BANNER);
+console.log(TestIds.APP_OPEN);
+console.log(TestIds.BANNER);
+console.log(TestIds.GAM_APP_OPEN);
+console.log(TestIds.GAM_BANNER);
+console.log(TestIds.GAM_INTERSTITIAL);
+console.log(TestIds.GAM_NATIVE);
+console.log(TestIds.GAM_REWARDED);
+console.log(TestIds.GAM_REWARDED_INTERSTITIAL);
+console.log(TestIds.INTERSTITIAL);
+console.log(TestIds.INTERSTITIAL_VIDEO);
+console.log(TestIds.REWARDED);
+console.log(TestIds.REWARDED_INTERSTITIAL);
+
+// AdEventType
+console.log(AdEventType.CLICKED);
+console.log(AdEventType.CLOSED);
+console.log(AdEventType.ERROR);
+console.log(AdEventType.LOADED);
+console.log(AdEventType.OPENED);
+console.log(AdEventType.PAID);
+
+// BannerAdSize
+console.log(BannerAdSize.ANCHORED_ADAPTIVE_BANNER);
+console.log(BannerAdSize.BANNER);
+console.log(BannerAdSize.FULL_BANNER);
+console.log(BannerAdSize.INLINE_ADAPTIVE_BANNER);
+console.log(BannerAdSize.LARGE_BANNER);
+console.log(BannerAdSize.LEADERBOARD);
+console.log(BannerAdSize.MEDIUM_RECTANGLE);
+console.log(BannerAdSize.WIDE_SKYSCRAPER);
+console.log(BannerAdSize.ADAPTIVE_BANNER);
+
+// GAMBannerAdSize
+console.log(GAMBannerAdSize.ANCHORED_ADAPTIVE_BANNER);
+console.log(GAMBannerAdSize.BANNER);
+console.log(GAMBannerAdSize.FLUID);
+console.log(GAMBannerAdSize.FULL_BANNER);
+console.log(GAMBannerAdSize.INLINE_ADAPTIVE_BANNER);
+console.log(GAMBannerAdSize.LARGE_BANNER);
+console.log(GAMBannerAdSize.LEADERBOARD);
+console.log(GAMBannerAdSize.MEDIUM_RECTANGLE);
+console.log(GAMBannerAdSize.WIDE_SKYSCRAPER);
+console.log(GAMBannerAdSize.ADAPTIVE_BANNER);
+
+// GAMAdEventType
+console.log(GAMAdEventType.APP_EVENT);
+
+// RewaredAdEventType
+console.log(RewardedAdEventType.LOADED);
+console.log(RewardedAdEventType.EARNED_REWARD);
+
+// AdsConsent
+AdsConsent.getConsentInfo().then(info => info.canRequestAds);
+AdsConsent.getGdprApplies().then(applies => applies);
+AdsConsent.getPurposeConsents().then(consents => consents);
+AdsConsent.getTCModel().then(model => model.cmpId);
+AdsConsent.getTCString().then(string => string);
+AdsConsent.getUserChoices().then(choices => choices.selectBasicAds);
+AdsConsent.loadAndShowConsentFormIfRequired().then(info => info.canRequestAds);
+AdsConsent.requestInfoUpdate().then(info => info.canRequestAds);
+AdsConsent.reset();
+AdsConsent.showForm().then(info => info.status);
+AdsConsent.showPrivacyOptionsForm().then(info => info.status);
+
+// AppOpenAd
+const appOpenAd = AppOpenAd.createForAdRequest('foo', {
+  keywords: ['test'],
+});
+
+console.log(appOpenAd.adUnitId);
+console.log(appOpenAd.loaded);
+
+appOpenAd.load();
+appOpenAd.show().then();
+
+appOpenAd.addAdEventListener(AdEventType.PAID, () => {});
+appOpenAd.addAdEventsListener(({ type, payload }) => {
+  if (payload) {
+    console.log(type);
+    console.log(payload instanceof Error && payload.message);
+    console.log('amount' in payload && payload.amount);
+    console.log('data' in payload && payload.data);
+  }
+});
+appOpenAd.removeAllListeners();
 
 // InterstitialAd
-const interstitial = googleMobileAds.InterstitialAd.createForAdRequest('foo', {
+const interstitial = InterstitialAd.createForAdRequest('foo', {
   keywords: ['test'],
 });
 
 console.log(interstitial.adUnitId);
+console.log(interstitial.loaded);
 
 interstitial.load();
 interstitial.show().then();
-interstitial.addAdEventsListener(({ type, payload }) => {
-  console.log(type);
-  console.log(payload instanceof Error && payload.message);
-  console.log('amount' in payload && payload.amount);
-  console.log('data' in payload && payload.type);
-});
 
-googleMobileAds.AdsConsent.requestInfoUpdate().then(info =>
-  console.log(info.isConsentFormAvailable),
-);
-googleMobileAds.AdsConsent.showForm().then(info => console.log(info.status));
-googleMobileAds.AdsConsent.reset();
+interstitial.addAdEventListener(AdEventType.PAID, () => {});
+interstitial.addAdEventsListener(({ type, payload }) => {
+  if (payload) {
+    console.log(type);
+    console.log(payload instanceof Error && payload.message);
+    console.log('amount' in payload && payload.amount);
+    console.log('data' in payload && payload.data);
+  }
+});
+interstitial.removeAllListeners();
 
 // RewardedAd
-const rewardedAd = googleMobileAds.RewardedAd.createForAdRequest('foo', {
+const rewardedAd = RewardedAd.createForAdRequest('foo', {
   keywords: ['test'],
 });
 
 console.log(rewardedAd.adUnitId);
+console.log(rewardedAd.loaded);
 
 rewardedAd.load();
 rewardedAd.show().then();
+
+rewardedAd.addAdEventListener(AdEventType.PAID, () => {});
 rewardedAd.addAdEventsListener(({ type, payload }) => {
-  console.log(type);
-  console.log(payload instanceof Error && payload.message);
-  console.log('amount' in payload && payload.amount);
-  console.log('data' in payload && payload.type);
+  if (payload) {
+    console.log(type);
+    console.log(payload instanceof Error && payload.message);
+    console.log('amount' in payload && payload.amount);
+    console.log('data' in payload && payload.data);
+  }
+});
+rewardedAd.removeAllListeners();
+
+// RewardedInterstitialAd
+const rewardedInterstitialAd = RewardedInterstitialAd.createForAdRequest('foo', {
+  keywords: ['test'],
 });
 
-// checks module exists at root
-console.log(googleMobileAds().app.name);
+console.log(rewardedInterstitialAd.adUnitId);
+console.log(rewardedInterstitialAd.loaded);
 
-// checks statics exist
-console.log(googleMobileAds.SDK_VERSION);
+rewardedInterstitialAd.load();
+rewardedInterstitialAd.show().then();
 
-// checks statics exist on defaultExport
-console.log(googleMobileAds.default.SDK_VERSION);
+rewardedInterstitialAd.addAdEventListener(AdEventType.PAID, () => {});
+rewardedInterstitialAd.addAdEventsListener(({ type, payload }) => {
+  if (payload) {
+    console.log(type);
+    console.log(payload instanceof Error && payload.message);
+    console.log('amount' in payload && payload.amount);
+    console.log('data' in payload && payload.data);
+  }
+});
+rewardedInterstitialAd.removeAllListeners();
 
-// checks firebase named export exists on module
-console.log(googleMobileAds.firebase.SDK_VERSION);
+// BannerAd
+console.log(BannerAd);
 
-// test banner sizes
-console.log(googleMobileAds.BannerAdSize.BANNER);
-console.log(googleMobileAds.BannerAdSize.FULL_BANNER);
-console.log(googleMobileAds.BannerAdSize.LARGE_BANNER);
-console.log(googleMobileAds.BannerAdSize.LEADERBOARD);
-console.log(googleMobileAds.BannerAdSize.MEDIUM_RECTANGLE);
+// GAMBannerAd
+console.log(GAMBannerAd);
+
+// GAMInterstitialAd
+const gmaInterstitialAd = GAMInterstitialAd.createForAdRequest('foo', {
+  keywords: ['test'],
+});
+
+console.log(gmaInterstitialAd.adUnitId);
+console.log(gmaInterstitialAd.loaded);
+
+gmaInterstitialAd.load();
+gmaInterstitialAd.show().then();
+
+gmaInterstitialAd.addAdEventListener(AdEventType.PAID, () => {});
+gmaInterstitialAd.addAdEventsListener(({ type, payload }) => {
+  if (payload) {
+    console.log(type);
+    console.log(payload instanceof Error && payload.message);
+    console.log('amount' in payload && payload.amount);
+    console.log('data' in payload && payload.data);
+  }
+});
+gmaInterstitialAd.removeAllListeners();
+
+// useAppOpenAd
+console.log(useAppOpenAd);
+
+// useInterstitialAd
+console.log(useInterstitialAd);
+
+// useRewardedAd
+console.log(useRewardedAd);
+
+// useRewardedInterstitialAd
+console.log(useRewardedInterstitialAd);
+
+// useForeground
+console.log(useForeground);


### PR DESCRIPTION
### Description

This PR fixes that our compile time type tests were never evaluated. Furthermore, it also updates the tests to include all types that have been added since their last update.

### Related issues

- Fixes #615 

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Made sure `yarn tsc:compile` now passes
- Checked that all types exported from `src/index.ts` are covered
