### PR TITLE
docs: clarify app.config.*s files are supported

### DIFF
--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -34,9 +34,10 @@ For Android, add the following rule into `android/app/proguard-rules.pro`:
 </TabItem>
 <TabItem value="expo">
 
-Add the `extraProguardRules` property to `app.json` file as described in the [Expo documentation](https://docs.expo.dev/versions/latest/sdk/build-properties/#pluginconfigtypeandroid):
+Add the `extraProguardRules` property to `app.json`, `app.config.js`, or `app.config.ts` file as described in the [Expo documentation](https://docs.expo.dev/versions/latest/sdk/build-properties/#pluginconfigtypeandroid):
 
 ```json
+// <project-root>/app.json
 {
   "expo": {
     "plugins": [
@@ -82,7 +83,7 @@ Within your projects `app.json` file, set the `delay_app_measurement_init` to `t
 </TabItem>
 <TabItem value="expo">
 
-Within your projects `app.json` file, set the `delayAppMeasurementInit` to `true` to delay app measurement:
+Within your projects `app.json`, `app.config.js`, or `app.config.ts` file, set the `delayAppMeasurementInit` to `true` to delay app measurement:
 
 ```json
 // <project-root>/app.json
@@ -111,7 +112,7 @@ Once set, rebuild your application.
 
 If you configure an [ATT message](https://support.google.com/admob/answer/10115331) in your Google AdMob account, the UMP SDK will automatically handle the ATT alert.
 This will also show an IDFA explainer message. If you don't want to show an explainer message you can show the ATT alert [manually](https://docs.page/invertase/react-native-google-mobile-ads#app-tracking-transparency-ios).
-Also, within your projects `app.json` file, you have to provide a user tracking usage description (once set, rebuild your application):
+Also, within your projects configuration file, you have to provide a user tracking usage description (once set, rebuild your application):
 
 <Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
 <TabItem value="bare">

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -51,7 +51,7 @@ To enable static frameworks, you must add the variable `$RNGoogleMobileAdsAsStat
 <TabItem value="expo">
 
 Expo users may enable static frameworks by using the `expo-build-properties` plugin.
-To do so [follow the official `expo-build-properties` installation instructions](https://docs.expo.dev/versions/latest/sdk/build-properties/) and merge the following code into your `app.json` file:
+To do so [follow the official `expo-build-properties` installation instructions](https://docs.expo.dev/versions/latest/sdk/build-properties/) and merge the following code into your `app.json`, `app.config.js`, or `app.config.ts` file:
 
 ```json
 // <project-root>/app.json
@@ -81,7 +81,7 @@ Before you are able to display ads to your users, you must have a [Google AdMob 
 be added to the project.
 
 <Warning>
-Attempting to build your app without a valid App ID in `app.json` will cause the app to crash on start or fail to build.
+Attempting to build your app without configuring a valid App ID for this package will cause the app to crash on start or fail to build.
 </Warning>
 
 Under the "App settings" menu item, you can find the "App ID":
@@ -89,7 +89,7 @@ Under the "App settings" menu item, you can find the "App ID":
 ![Google AdMob App ID](https://prismic-io.s3.amazonaws.com/invertase%2F52dd6900-108c-47a6-accb-699fde963b99_new+project+%2813%29.jpg)
 
 The app IDs for Android and iOS need to be inserted into your apps native code.
-For React Native projects without Expo, you can add the app IDs to the `app.json` file.
+For bare React Native projects, you can add the app IDs to the `app.json` file.
 For Expo projects, we provide an [Expo config plugin](https://docs.expo.dev/config-plugins/introduction/).
 
 
@@ -120,7 +120,7 @@ npx react-native run-android
 </TabItem>
 <TabItem value="expo">
 
-This library contains an Expo config plugin which you must add to your `app.json` file.
+This library contains an Expo config plugin which you must add to your `app.json`, `app.config.js`, or `app.config.ts` file.
 For these changes to take effect, your must rebuild your project's native code and install the new build on your device.
 
 ```json
@@ -228,7 +228,7 @@ If you are using mediation, you may wish to wait until the promise is settled be
 ### Enable SKAdNetwork to track conversions (iOS)
 
 The Google Mobile Ads SDK supports conversion tracking using Apple's SKAdNetwork, which lets Google and participating third-party buyers attribute an app install even when the IDFA is not available.
-Within your projects `app.json` file, add the advised [SKAdNetwork identifiers](https://developers.google.com/ad-manager/mobile-ads-sdk/ios/3p-skadnetworks).
+Add the advised [SKAdNetwork identifiers](https://developers.google.com/ad-manager/mobile-ads-sdk/ios/3p-skadnetworks) to your project as described below.
 Note that these identifiers are subject to change and should be updated regularly.
 
 <Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
@@ -372,7 +372,7 @@ Note that these identifiers are subject to change and should be updated regularl
 ### App Tracking Transparency (iOS)
 
 Apple requires apps to display the App Tracking Transparency authorization request for accessing the IDFA (leaving the choice to the user, whether to use personalized or non-personalized ads).
-Within your projects `app.json` file, you have to provide a user tracking usage description:
+Within your projects configuration file, you have to provide a user tracking usage description:
 
 <Tabs groupId="framework" values={[{label: 'React Native', value: 'bare'}, {label: 'Expo', value: 'expo'}]}>
 <TabItem value="bare">


### PR DESCRIPTION
### Description

This PR clarifies that `app.config.js` and `app.config.ts` files are still supported (just like `app.json` files).

~This PR complements the `app.json` config examples with `app.config.js` and `app.config.ts` examples.~

~I was hoping we would not have to do this since it's somewhar cluttering the docs, but I tried to compensate that by using docs.page accordion components. Also tried using nested tabs, but they don't appear to be supported (i.e. they don't render correctly).~

### Related issues

- #620
  Hope this helps with issues like this, where some people got the impression that `app.config.*s` support was dropped

### Test Plan

- Validate the changes via the [docs preview](https://docs.page/DoctorJohn/react-native-google-ads~add-app-config-examples)
