### PR TITLE
fix: non-eas expo android builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,23 +80,25 @@ def appJSONGoogleMobileAdsDelayAppMeasurementInitBool = false
 def appJSONGoogleMobileAdsOptimizeInitializationBool = true
 def appJSONGoogleMobileAdsOptimizeAdLoadingBool = true
 
-if (rootProject.ext.has("googleMobileAdsJson")) {
-  appJSONGoogleMobileAdsAppIDString = rootProject.ext.googleMobileAdsJson.getStringValue("android_app_id", "")
-  appJSONGoogleMobileAdsDelayAppMeasurementInitBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("delay_app_measurement_init", false)
-  appJSONGoogleMobileAdsOptimizeInitializationBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("optimize_initialization", true)
-  appJSONGoogleMobileAdsOptimizeAdLoadingBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("optimize_ad_loading", true)
-}
+if (!isManagedExpoProject) {
+  if (rootProject.ext.has("googleMobileAdsJson")) {
+    appJSONGoogleMobileAdsAppIDString = rootProject.ext.googleMobileAdsJson.getStringValue("android_app_id", "")
+    appJSONGoogleMobileAdsDelayAppMeasurementInitBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("delay_app_measurement_init", false)
+    appJSONGoogleMobileAdsOptimizeInitializationBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("optimize_initialization", true)
+    appJSONGoogleMobileAdsOptimizeAdLoadingBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("optimize_ad_loading", true)
+  }
 
-if (!appJSONGoogleMobileAdsAppIDString && !isManagedExpoProject) {
-  println "\n\n\n"
-  println "**************************************************************************************************************"
-  println "\n\n\n"
-  println "ERROR: react-native-google-mobile-ads requires an 'android_app_id' property inside a 'react-native-google-mobile-ads' key in your app.json."
-  println "  No android_app_id property was found in this location. The native Google Mobile Ads SDK will crash on startup without it."
-  println "\n\n\n"
-  println "**************************************************************************************************************"
-  println "\n\n\n"
-  System.exit(1)
+  if (!appJSONGoogleMobileAdsAppIDString) {
+    println "\n\n\n"
+    println "**************************************************************************************************************"
+    println "\n\n\n"
+    println "ERROR: react-native-google-mobile-ads requires an 'android_app_id' property inside a 'react-native-google-mobile-ads' key in your app.json."
+    println "  No android_app_id property was found in this location. The native Google Mobile Ads SDK will crash on startup without it."
+    println "\n\n\n"
+    println "**************************************************************************************************************"
+    println "\n\n\n"
+    System.exit(1)
+  }
 }
 
 android {


### PR DESCRIPTION
### Description

This PR fixes non-eas expo Android builds.

To create a non-eas expo build, users first run `npx expo prebuild` which generates native android and ios files. At this point the project is no longer considered a managed expo project but a bare react native project. This bare react native project has its native files already fully configured by expo prebuild (i.e. the admob app ID is already present in the AndroidManifest.xml file).
In this scenario we also want the custom configuration workflow to bail out, however, our expo detection does no longer work.

~Before this PR, building such a fully configured bare react native android project failed, because our build.gradle script assumed the project is a bare react native project and still requires configuration. The custom config workflow build.gradle script then tries to obtain the relevant config keys from the app.json file which fails with the error message reported in #620.~

Edit: while this PR indeed fixes the linked issue, I'm not fully sure the second half of my explanation above is correct. Converted this to a draft while thinking about it.
Edit2: This PR only works because of a bug. The android and ios file paths in the build.gradle file are wrong. This is only affecting the error messages shown for incorrectly configured projects (hence I never noticed this issue). Correctly configured projects are not affected.

### Related issues

- Fixes #620

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- I cloned the repro provided in #620, updated the `app.config.js` file to include a valid admob id, ran `npx expo prebuild --clean` and then successfully built and ran the app via `yarn android`
- I also verified that EAS android builds still work as expected
