### PR TITLE
fix: building without an app.json file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,29 +74,28 @@ project.ext {
 
 apply from: file("./app-json.gradle")
 
-def isManagedExpoProject = !rootProject.file("android").exists() && !rootProject.file("ios").exists()
 def appJSONGoogleMobileAdsAppIDString = ""
 def appJSONGoogleMobileAdsDelayAppMeasurementInitBool = false
 def appJSONGoogleMobileAdsOptimizeInitializationBool = true
 def appJSONGoogleMobileAdsOptimizeAdLoadingBool = true
 
-if (rootProject.ext.has("googleMobileAdsJson")) {
+if (rootProject.ext.has("googleMobileAdsJson") && rootProject.ext.googleMobileAdsJson) {
   appJSONGoogleMobileAdsAppIDString = rootProject.ext.googleMobileAdsJson.getStringValue("android_app_id", "")
   appJSONGoogleMobileAdsDelayAppMeasurementInitBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("delay_app_measurement_init", false)
   appJSONGoogleMobileAdsOptimizeInitializationBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("optimize_initialization", true)
   appJSONGoogleMobileAdsOptimizeAdLoadingBool = rootProject.ext.googleMobileAdsJson.isFlagEnabled("optimize_ad_loading", true)
 }
 
-if (!appJSONGoogleMobileAdsAppIDString && !isManagedExpoProject) {
+if (!appJSONGoogleMobileAdsAppIDString) {
   println "\n\n\n"
   println "**************************************************************************************************************"
   println "\n\n\n"
-  println "ERROR: react-native-google-mobile-ads requires an 'android_app_id' property inside a 'react-native-google-mobile-ads' key in your app.json."
-  println "  No android_app_id property was found in this location. The native Google Mobile Ads SDK will crash on startup without it."
+  println "WARNING: react-native-google-mobile-ads requires an 'android_app_id' property inside a 'react-native-google-mobile-ads' key in your app.json."
+  println "         No android_app_id property was found in this location. The native Google Mobile Ads SDK will crash on startup without it."
+  println "         You can safely ignore this warning if you are using our Expo config plugin."
   println "\n\n\n"
   println "**************************************************************************************************************"
   println "\n\n\n"
-  System.exit(1)
 }
 
 android {

--- a/ios_config.sh
+++ b/ios_config.sh
@@ -88,12 +88,6 @@ while true; do
   _CURRENT_LOOKUPS=$((_CURRENT_LOOKUPS+1))
 done
 
-# Bail out if project is a managed Expo project:
-if [[ ! -d "${PROJECT_DIR}/ios" ]] && [[ ! -d "${PROJECT_DIR}/android" ]]; then
-  echo "info: Project does not contain an ios or android folder, assume it's a managed Expo project using our Expo Config Plugin."
-  exit 0
-fi
-
 if [[ ${_SEARCH_RESULT} ]]; then
   _JSON_OUTPUT_RAW=$(cat "${_SEARCH_RESULT}")
   _RN_ROOT_EXISTS=$(ruby -KU -e "require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output[$_JSON_ROOT]" || echo '')
@@ -169,8 +163,9 @@ if ! [[ -f "${_TARGET_PLIST}" ]]; then
 fi
 
 if ! [[ $_IOS_APP_ID ]]; then
-  echo "error: ios_app_id key not found in react-native-google-mobile-ads key in app.json. App will crash without it."
-  exit 1
+  echo "warning: ios_app_id key not found in react-native-google-mobile-ads key in app.json. App will crash without it."
+  echo "         You can safely ignore this warning if you are using our Expo config plugin."
+  exit 0
 fi
 
 for plist in "${_TARGET_PLIST}" "${_DSYM_PLIST}" ; do


### PR DESCRIPTION
### Description

This PR fixes builds of projects that don't have app.json file at all.

This is done by fixing two bugs:
1. The bailout conditions added in #616 turned out to be tautoligical. They try to detect managed expo projects during build time by checking the existance of `android` and `ios` folders. These folders will always exist during build time rendering the checks useless. As a result bare react native projects without a valid app.json no longer fail at build time. Note that correctly configured projects are not affected by this bug at all (that's why my testing did not reveal this bug).
2. Builds of any android app without app.json files currently fail because of a missing check for the availability of the parsed contents of that file.

Note that this PR fully removes the bailout conditions in both `build.gradle` and `ios_config.sh`. Unfortunately we have no sufficient replacement. The check used before #616 works at build time but does not work with the use case outlined in #614. Without a valid bailout condition we lose the ability to let build.gradle and ios_config.sh fail when a bare react native project does not have a valid app.json file. Instead we now show a warning during build time when no admob app ids are found in app.json or app.json does not exist at all.

### Related issues

- Fixes #620

### Test Plan

- I confirmed managed expo projects build showing the expected warning and run successfully (on android) 
- I confirmed the example project builds and runs as-is (on android)
- I confirmed the example project builds, but yields a warning if no admob app ids are provided (on android)
- I confirmed the repro in #630 builds showing the expected warning and runs successfully (on android)

Here is how to validate that this PR actually fixes the linked issue:

```bash
git clone https://github.com/jpdriver/expo-google-ads-repro.git
cd expo-google-ads-repro
git checkout 992e726314c7855dd493ac5d3e529c4a5328e37b
yarn add "git+https://github.com/DoctorJohn/react-native-google-ads.git#hotfix-builds-without-app-json"
sed -i 's/"androidAppId": "ca-app-pub-xxxxxxxx~xxxxxxxx"/"androidAppId": "ca-app-pub-3940256099942544~3347511713"/g' app.config.js
npx expo prebuild --clean
yarn android
```

Note that I was only able to test on android this time. It would be benefitial if someone could verify these changes on ios too. To do so run the example app included in this repo on ios AND run the following commands in addition to the ones above to verify this PR works with the repro in the linked issue:

```
sed -i 's/"iosAppId": "ca-app-pub-xxxxxxxx~xxxxxxxx"/"iosAppId": "ca-app-pub-3940256099942544~1458002511"/g' app.config.js
sed -i 's/true/true,\n\t\t\t"bundleIdentifier": "com.anonymous.myapp"/g' app.config.js
npx expo prebuild --clean
yarn ios
```

