### PR TITLE
fix: set default internal request agent

### DIFF
--- a/src/validateAdRequestOptions.ts
+++ b/src/validateAdRequestOptions.ts
@@ -24,6 +24,7 @@ import {
   isUndefined,
   isValidUrl,
 } from './common';
+import { version } from './version';
 import { RequestOptions } from './types/RequestOptions';
 
 export function validateAdRequestOptions(options?: RequestOptions) {
@@ -97,6 +98,8 @@ export function validateAdRequestOptions(options?: RequestOptions) {
     }
 
     out.requestAgent = options.requestAgent;
+  } else {
+    out.requestAgent = `rn-invertase-${version}`;
   }
 
   if (options.serverSideVerificationOptions) {


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
