### PR TITLE
docs: work around issue with docs.page codeblocks

### DIFF
--- a/docs/impression-level-ad-revenue.mdx
+++ b/docs/impression-level-ad-revenue.mdx
@@ -23,7 +23,7 @@ To use this feature:
 
 The `PaidEvent` type is:
 
-```ts
+```tsx
 type PaidEvent = {
   currency: string;
   precision: RevenuePrecisions;
@@ -34,7 +34,7 @@ type PaidEvent = {
 where `RevenuePrecisions` is an enum with keys `ESTIMATED`, `PRECISE`,
 `PUBLISHER_PROVIDED`, and `UNKNOWN`. It can be imported from the library as
 
-```ts
+```tsx
 import { RevenuePrecisions } from 'react-native-google-mobile-ads';
 ```
 


### PR DESCRIPTION
### Description

Our docs for impression-level ad revenue are currently down. They used to work perfectly but stopped working a few days ago. I suspect the recent major docs.page update.

The page currently returns status 500. Through trial and error, I narrowed the issue down to the two code blocks on that page. The page fails to render when the codeblocks use `ts` as their language. Curiously enough, changing the language to `tsx` resolves the issue.

I just reported the issue upstream: https://github.com/invertase/docs.page/issues/364
If we don't want to wait for it to get addressed, we can switch the affected code blocks to `tsx`.

### Test Plan

- Checked the docs.page preview for the updated docs
