### PR TITLE
fix: type tests were messing with type generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lint:markdown:fix": "prettier --write \"docs/**/*.md[x]\"",
     "lint:report": "eslint --output-file=eslint-report.json --format=json src/ --ext .js,.jsx,.ts,.tsx",
     "lint:spellcheck": "spellchecker --quiet --files=\"docs/**/*.md\" --dictionaries=\"./.spellcheck.dict.txt\" --reports=\"spelling.json\" --plugins spell indefinite-article repeated-words syntax-mentions syntax-urls frontmatter",
-    "tsc:compile": "tsc --project . --noEmit",
+    "tsc:compile": "tsc --project tsconfig.test.json",
     "lint": "yarn lint:code && yarn tsc:compile",
     "tests:jest": "jest",
     "tests:jest-watch": "jest --watch",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "type-test.ts"],
+  "include": ["src"],
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["type-test.ts"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
### Description

As reported in https://github.com/invertase/react-native-google-mobile-ads/issues/631#issuecomment-2397953899, PR #619 broke the generation of TS types shipped with the package.

The reason for this is the inclusion of the `type-test.ts` file in the `include` array in the `tsconfig.json` file. This was done so that the `tsc:compile` script used by the lint CI workflow would try to compile that file and report any issues with it. This was inspired by how it's done in the [react-native-firebase repo's tsconfig.json](https://github.com/invertase/react-native-firebase/blob/9c940857a3759f85fad2f8d995b83f7c08058d6b/tsconfig.json#L2).
However, unlike react-native-fiebase we ship those compiled files and the inclusion of the `type-test.ts` file is messing with the structure of the output files. Without the inclusion of the `type-test.ts` file, `yarn build` puts the types into `lib/typescript`. With the inclusion of the `type-test.ts` file, `yarn build` puts the type into `lib/typescript/src` - which is causing the reported issue.

This PR splits the `tsconfig.json` file into one used for compiling the types we ship and a `tsconfig.test.json` file used by the `tsc:compile` script for linting / testing the types.


### Test Plan

- `yarn build` outputs the expected types again
- `yarn tsc:compile` still passes
- `yarn tsc:compile` fails if any non-existing property is accessed from the `type-test.ts` file

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
