### PR TITLE
fix(android): disable coalescing of native events

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/OnNativeEvent.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/OnNativeEvent.kt
@@ -11,6 +11,8 @@ class OnNativeEvent(viewId: Int, private val event: WritableMap) : Event<OnNativ
 
     override fun getCoalescingKey(): Short = 0
 
+    override fun canCoalesce(): Boolean = false
+
     override fun getEventData(): WritableMap? {
         return event
     }


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
Disable native event coalescing by setting canCoalesce to false. This library uses a single event definition for multiple events. If they happen almost at the same time, some events would otherwise get ignored.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
N/A

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->
android: Fix issue where some native events may not be triggered

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
