### PR TITLE
feat: get purpose legitimate interests

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
@@ -278,4 +278,16 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
       rejectPromiseWithCodeAndMessage(promise, "consent-string-error", e.toString());
     }
   }
+
+  @ReactMethod
+  public void getPurposeLegitimateInterests(Promise promise) {
+    try {
+      SharedPreferences prefs =
+          PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
+      String purposeLegitimateInterests = prefs.getString("IABTCF_PurposeLegitimateInterests", "");
+      promise.resolve(purposeLegitimateInterests);
+    } catch (Exception e) {
+      rejectPromiseWithCodeAndMessage(promise, "consent-string-error", e.toString());
+    }
+  }
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.m
@@ -248,4 +248,20 @@ RCT_EXPORT_METHOD(getPurposeConsents
   }
 }
 
+RCT_EXPORT_METHOD(getPurposeLegitimateInterests
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+  @try {
+    NSString *purposeLegitimateInterests =
+        [[NSUserDefaults standardUserDefaults] stringForKey:@"IABTCF_PurposeLegitimateInterests"];
+    resolve(purposeLegitimateInterests);
+  } @catch (NSError *error) {
+    [RNSharedUtils rejectPromiseWithUserInfo:reject
+                                    userInfo:[@{
+                                      @"code" : @"consent-string-error",
+                                      @"message" : error.localizedDescription,
+                                    } mutableCopy]];
+  }
+}
+
 @end

--- a/src/AdsConsent.ts
+++ b/src/AdsConsent.ts
@@ -112,6 +112,10 @@ export const AdsConsent: AdsConsentInterface = {
     return native.getPurposeConsents();
   },
 
+  getPurposeLegitimateInterests(): Promise<string> {
+    return native.getPurposeLegitimateInterests();
+  },
+
   async getUserChoices(): Promise<AdsConsentUserChoices> {
     const tcString = await native.getTCString();
 

--- a/src/types/AdsConsent.interface.ts
+++ b/src/types/AdsConsent.interface.ts
@@ -157,6 +157,26 @@ export interface AdsConsentInterface {
   getPurposeConsents(): Promise<string>;
 
   /**
+   * Returns the value stored under the `IABTCF_PurposeLegitimateInterests` key
+   * in NSUserDefaults (iOS) / SharedPreferences (Android) as
+   * defined by the IAB Europe Transparency & Consent Framework.
+   *
+   * More information available here:
+   * https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#in-app-details
+   *
+   * #### Example
+   *
+   * ```js
+   * import { AdsConsent } from '@invertase/react-native-google-ads';
+   *
+   * await AdsConsent.requestInfoUpdate();
+   * const purposeLegitimateInterests = await AdsConsent.getPurposeLegitimateInterests();
+   * const hasLegitimateInterestForPurposeTwo = purposeLegitimateInterests.split("")[1] === "1";
+   * ```
+   */
+  getPurposeLegitimateInterests(): Promise<string>;
+
+  /**
    * Provides information about a user's consent choices.
    *
    * #### Example

--- a/type-test.ts
+++ b/type-test.ts
@@ -149,6 +149,7 @@ console.log(RewardedAdEventType.EARNED_REWARD);
 AdsConsent.getConsentInfo().then(info => info.canRequestAds);
 AdsConsent.getGdprApplies().then(applies => applies);
 AdsConsent.getPurposeConsents().then(consents => consents);
+AdsConsent.getPurposeLegitimateInterests().then(legitimateInterests => legitimateInterests);
 AdsConsent.getTCModel().then(model => model.cmpId);
 AdsConsent.getTCString().then(string => string);
 AdsConsent.getUserChoices().then(choices => choices.selectBasicAds);


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
Add a function to get purpose legitimate interests.

This library exposes a function to get purpose consents; however it lacks a function to get the status of purpose legitimate interests. Knowing which legitimate interests were selected (or rather deselected) is essential. This information helps determine what type of ads will be served to the user (personalized, non-personalized or limited ads), if any.
More about it here:
https://developers.google.com/admob/ios/privacy/ad-serving-modes

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
N/A

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter

🔥