### PR TITLE
feat: gather consent method to make user consent easier

### DIFF
--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -198,22 +198,17 @@ import mobileAds, { AdsConsent, AdsConsentStatus } from 'react-native-google-mob
 
 let isMobileAdsStartCalled = false;
 
-// Request an update for the consent information.
-AdsConsent.requestInfoUpdate().then(() => {
-
-  AdsConsent.loadAndShowConsentFormIfRequired().then(adsConsentInfo => {
-
-    // Consent has been gathered.
-    if (adsConsentInfo.canRequestAds) {
+// Request consent information and load/present a consent form if necessary.
+AdsConsent.gatherConsent()
+  .then(({canRequestAds}) => {
+    if (canRequestAds) {
       startGoogleMobileAdsSDK()
     }
   })
-})
+  .catch((error) => console.error('Consent gathering failed:', error))
 
-// Check if you can initialize the Google Mobile Ads SDK in parallel
-// while checking for new consent information. Consent obtained in
-// the previous session can be used to request ads.
-// So you can start loading ads as soon as possible after your app launches.
+// Check if you can initialize the Google Mobile Ads SDK in parallel 
+// using consent obtained in the previous session.
 const {canRequestAds} = await AdsConsent.getConsentInfo()
 if (canRequestAds) {
   startGoogleMobileAdsSDK()
@@ -221,7 +216,6 @@ if (canRequestAds) {
 
 async function startGoogleMobileAdsSDK() {
   if (isMobileAdsStartCalled) return;
-
   isMobileAdsStartCalled = true;
 
   // (Optional, iOS) Handle Apple's App Tracking Transparency manually.

--- a/src/AdsConsent.ts
+++ b/src/AdsConsent.ts
@@ -91,6 +91,11 @@ export const AdsConsent: AdsConsentInterface = {
     return native.getConsentInfo();
   },
 
+  async gatherConsent(options: AdsConsentInfoOptions = {}): Promise<AdsConsentInfo> {
+    await this.requestInfoUpdate(options);
+    return this.loadAndShowConsentFormIfRequired();
+  },
+
   reset(): void {
     return native.reset();
   },

--- a/src/types/AdsConsent.interface.ts
+++ b/src/types/AdsConsent.interface.ts
@@ -87,6 +87,12 @@ export interface AdsConsentInterface {
   getConsentInfo(): Promise<AdsConsentInfo>;
 
   /**
+   * Helper method to call the UMP SDK methods to request consent information and load/present a
+   * consent form if necessary.
+   */
+  gatherConsent(): Promise<AdsConsentInfo>;
+
+  /**
    * Returns the value stored under the `IABTCF_TCString` key
    * in NSUserDefaults (iOS) / SharedPreferences (Android) as
    * defined by the IAB Europe Transparency & Consent Framework.


### PR DESCRIPTION
### Description

While checking the official ios docs for changes I noticed that Google uses a helper method in their examples which I think can benefit this library too. Making it less cumbersome to show a consent form when necessary.

So you don't first have to call `requestInfoUpdate` and then `loadAndShowConsentFormIfRequired `.
But just `gatherConsent`.

See: https://github.com/googleads/googleads-mobile-ios-examples/blob/043de5a21d5b529ded1fb845f9f8082d130113f8/Objective-C/admob/BannerExample/BannerExample/GoogleMobileAdsConsentManager.m#L45

And: https://developers.google.com/admob/ios/privacy#request-ads