### PR TITLE
fix: resolve AndroidManifest conflict for AD_SERVICES_CONFIG

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -20,6 +20,23 @@
       <meta-data
         android:name="com.google.android.gms.ads.flag.OPTIMIZE_AD_LOADING"
         android:value="${appJSONGoogleMobileAdsOptimizeAdLoading}"/>
+
+      <!-- This may generate a warning during your build:
+
+           > property#android.adservices.AD_SERVICES_CONFIG@android:resource
+           > was tagged at AndroidManifest.xml:23 to replace other declarations
+           > but no other declaration present
+
+           You may safely ignore this warning.
+
+           We must include this in case you also use Firebase Analytics in some
+           of its configurations, as it may also include this file, and the two
+           will collide and cause a build error if we don't set this one to take
+           priority via replacement.
+
+           https://github.com/invertase/react-native-google-mobile-ads/issues/657
+
+      -->
       <property
         android:name="android.adservices.AD_SERVICES_CONFIG"
         android:resource="@xml/gma_ad_services_config"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="io.invertase.googlemobileads">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -19,5 +20,9 @@
       <meta-data
         android:name="com.google.android.gms.ads.flag.OPTIMIZE_AD_LOADING"
         android:value="${appJSONGoogleMobileAdsOptimizeAdLoading}"/>
+      <property
+        android:name="android.adservices.AD_SERVICES_CONFIG"
+        android:resource="@xml/gma_ad_services_config"
+        tools:replace="android:resource" />
     </application>
 </manifest>


### PR DESCRIPTION
### Description

This PR resolves a conflict in AndroidManifest.xml for the property android.adservices.AD_SERVICES_CONFIG. The issue occurs when both react-native-google-mobile-ads (via play-services-ads-lite) and @react-native-firebase/analytics (via play-services-measurement-api) declare the same property, causing a build failure.

By adding tools:replace="android:resource" to the <property> element in the react-native-google-mobile-ads manifest, this library takes precedence, resolving the conflict and allowing the project to build successfully.

### Related issues

Fixes #657 

### Release Summary

Added tools:replace="android:resource" to <property> in AndroidManifest.xml of react-native-google-mobile-ads.
This ensures compatibility when used with libraries like @react-native-firebase/analytics.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan


1. Create a new bare Expo project:
```
$ expo init
Choose the minimal and bare template.
```
2. Install the required libraries:
```
yarn add react-native-google-mobile-ads
yarn add @react-native-firebase/analytics
yarn add @react-native-firebase/app
yarn add expo-build-properties
```
3. Apply this change and attempt to build the project for Android.
4. Confirm that the build succeeds without requiring manual changes to the manifest.
`npx expo run:android`
=> BUILD SUCCESSFUL