### PR TITLE
fix(android): use currentActivity in initialize if !null, aids use of mediation adapters

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.kt
@@ -95,6 +95,11 @@ class ReactNativeGoogleMobileAdsModule(
   @ReactMethod
   fun initialize(promise: Promise) {
     MobileAds.initialize(
+      // in react-native, the Activity instance *may* go away, becoming null after initialize
+      // it is not clear if that can happen here without an initialize necessarily following the Activity lifecycle
+      // it is not clear if that will cause problems even if it happens, but users that have widely deployed this
+      // with the use of currentActivity have not seen problems
+      // reference if it needs attention: https://github.com/invertase/react-native-google-mobile-ads/pull/664
       currentActivity ?: reactApplicationContext,
       OnInitializationCompleteListener { initializationStatus ->
         val result = Arguments.createArray()

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.kt
@@ -95,7 +95,7 @@ class ReactNativeGoogleMobileAdsModule(
   @ReactMethod
   fun initialize(promise: Promise) {
     MobileAds.initialize(
-      reactApplicationContext,
+      currentActivity ?: reactApplicationContext,
       OnInitializationCompleteListener { initializationStatus ->
         val result = Arguments.createArray()
         for ((key, value) in initializationStatus.adapterStatusMap) {


### PR DESCRIPTION
### Description
Required for Unity Ads to function in mediation, as far as I can see shouldn't effect anything else

### Release Summary
Use currentActivity to initialise ads if available
<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [ x] Yes
- My change supports the following platforms;
  - [ x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ x] No
🔥
