### PR TITLE
feat: update mobile ads sdk, ump sdk and add new geography options

### DIFF
--- a/__tests__/consent.test.ts
+++ b/__tests__/consent.test.ts
@@ -12,7 +12,7 @@ describe('Google Mobile Ads AdsConsent', function () {
     it('throws if options.debugGeography is not a valid value.', function () {
       // @ts-ignore
       expect(() => AdsConsent.requestInfoUpdate({ debugGeography: -1 })).toThrowError(
-        "AdsConsent.requestInfoUpdate(*) 'options.debugGeography' expected one of AdsConsentDebugGeography.DISABLED, AdsConsentDebugGeography.EEA or AdsConsentDebugGeography.NOT_EEA.",
+        "AdsConsent.requestInfoUpdate(*) 'options.debugGeography' expected one of AdsConsentDebugGeography.DISABLED, AdsConsentDebugGeography.EEA, AdsConsentDebugGeography.NOT_EEA, AdsConsentDebugGeography.REGULATED_US_STATE or AdsConsentDebugGeography.OTHER.",
       );
     });
 

--- a/package.json
+++ b/package.json
@@ -43,16 +43,16 @@
   ],
   "sdkVersions": {
     "ios": {
-      "googleMobileAds": "11.10.0",
-      "googleUmp": "2.6.0"
+      "googleMobileAds": "11.13.0",
+      "googleUmp": "2.7.0"
     },
     "android": {
       "minSdk": 21,
       "targetSdk": 34,
       "compileSdk": 34,
       "buildTools": "34.0.0",
-      "googleMobileAds": "23.4.0",
-      "googleUmp": "3.0.0"
+      "googleMobileAds": "23.6.0",
+      "googleUmp": "3.1.0"
     }
   },
   "react-native-builder-bob": {

--- a/src/AdsConsent.ts
+++ b/src/AdsConsent.ts
@@ -36,10 +36,12 @@ export const AdsConsent: AdsConsentInterface = {
       isPropertySet(options, 'debugGeography') &&
       options.debugGeography !== AdsConsentDebugGeography.DISABLED &&
       options.debugGeography !== AdsConsentDebugGeography.EEA &&
-      options.debugGeography !== AdsConsentDebugGeography.NOT_EEA
+      options.debugGeography !== AdsConsentDebugGeography.NOT_EEA &&
+      options.debugGeography !== AdsConsentDebugGeography.REGULATED_US_STATE &&
+      options.debugGeography !== AdsConsentDebugGeography.OTHER
     ) {
       throw new Error(
-        "AdsConsent.requestInfoUpdate(*) 'options.debugGeography' expected one of AdsConsentDebugGeography.DISABLED, AdsConsentDebugGeography.EEA or AdsConsentDebugGeography.NOT_EEA.",
+        "AdsConsent.requestInfoUpdate(*) 'options.debugGeography' expected one of AdsConsentDebugGeography.DISABLED, AdsConsentDebugGeography.EEA, AdsConsentDebugGeography.NOT_EEA, AdsConsentDebugGeography.REGULATED_US_STATE or AdsConsentDebugGeography.OTHER.",
       );
     }
 

--- a/src/specs/modules/NativeConsentModule.ts
+++ b/src/specs/modules/NativeConsentModule.ts
@@ -30,14 +30,24 @@ export enum AdsConsentDebugGeography {
   DISABLED = 0,
 
   /**
-   * Sets the location to within the EEA.
+   * Geography appears as in EEA for debug devices.
    */
   EEA = 1,
 
   /**
-   * Sets the location to outside of the EEA.
+   * @deprecated Use `OTHER`.
    */
   NOT_EEA = 2,
+
+  /**
+   * Geography appears as in a regulated US State.
+   */
+  REGULATED_US_STATE = 3,
+
+  /**
+   * Geography appears as in a region with no regulation in force.
+   */
+  OTHER = 4,
 }
 
 /**


### PR DESCRIPTION
### Description
UMP SDK release notes:
To support testing with regulated US states, added the following options to [UMPDebugGeography](https://developers.google.com/admob/ios/privacy/api/reference/Enums/UMPDebugGeography):
UMPDebugGeographyRegulatedUSState
UMPDebugGeographyOther
Deprecated UMPDebugGeographyNotEEA. Use UMPDebugGeographyOther instead.