### PR TITLE
fix: warning requiresMainQueueSetup

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.mm
@@ -54,6 +54,10 @@ RCT_EXPORT_MODULE();
   return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 RCT_EXPORT_METHOD(appOpenLoad
                   : (double)requestId adUnitId
                   : (NSString *)adUnitId requestOptions

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.mm
@@ -56,6 +56,10 @@ RCT_EXPORT_MODULE();
   return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 RCT_EXPORT_METHOD(interstitialLoad
                   : (double)requestId adUnitId
                   : (NSString *)adUnitId requestOptions

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsModule.mm
@@ -36,6 +36,10 @@ RCT_EXPORT_MODULE();
   return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 #pragma mark -
 #pragma mark Google Mobile Ads Methods
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedInterstitialModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedInterstitialModule.mm
@@ -56,6 +56,10 @@ RCT_EXPORT_MODULE();
   return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 RCT_EXPORT_METHOD(rewardedInterstitialLoad
                   : (double)requestId adUnitId
                   : (NSString *)adUnitId requestOptions

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.mm
@@ -54,6 +54,10 @@ RCT_EXPORT_MODULE();
   return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 RCT_EXPORT_METHOD(rewardedLoad
                   : (double)requestId adUnitId
                   : (NSString *)adUnitId requestOptions


### PR DESCRIPTION
### Description

requiresMainQueueSetup was accidentally removed by #662, which now triggers warnings that it requires main queue setup.
This PR brings them back.