### PR TITLE
feat(banner): allow adaptive banners to use their container's width

### DIFF
--- a/RNGoogleMobileAdsExample/App.tsx
+++ b/RNGoogleMobileAdsExample/App.tsx
@@ -185,9 +185,8 @@ class InterstitialTest implements Test {
 class BannerTest implements Test {
   bannerAdSize: BannerAdSize | string;
 
-  constructor(bannerAdSize) {
+  constructor(bannerAdSize: BannerAdSize | string) {
     this.bannerAdSize = bannerAdSize;
-    this.bannerRef = React.createRef();
   }
 
   getPath(): string {
@@ -205,30 +204,11 @@ class BannerTest implements Test {
 
   render(onMount: (component: any) => void): React.ReactNode {
     return (
-      <View ref={onMount}>
-        <BannerAd
-          ref={this.bannerRef}
-          unitId={
-            this.bannerAdSize.includes('ADAPTIVE_BANNER')
-              ? TestIds.ADAPTIVE_BANNER
-              : TestIds.BANNER
-          }
-          size={this.bannerAdSize}
-          onPaid={(event: PaidEvent) => {
-            console.log(
-              `Paid: ${event.value} ${event.currency} (precision ${
-                RevenuePrecisions[event.precision]
-              }})`,
-            );
-          }}
-        />
-        <Button
-          title="reload"
-          onPress={() => {
-            this.bannerRef.current?.load();
-          }}
-        />
-      </View>
+      <BannerContainer
+        ref={onMount}
+        bannerAdSize={this.bannerAdSize}
+      />
+
     );
   }
 
@@ -241,6 +221,58 @@ class BannerTest implements Test {
     } finally {
       complete(results);
     }
+  }
+}
+
+
+class BannerContainer extends React.Component<{ bannerAdSize: string }, { enableContainerAdaptiveMode: boolean }> {
+  state = {
+    enableContainerAdaptiveMode: true
+  }
+  bannerRef = React.createRef();
+
+
+  render(): React.ReactNode {
+    return (
+      <>
+        <View style={{ width: "50%"}}>
+          <BannerAd
+            ref={this.bannerRef}
+            unitId={
+              this.props.bannerAdSize.includes('ADAPTIVE_BANNER')
+                ? TestIds.ADAPTIVE_BANNER
+                : TestIds.BANNER
+            }
+            size={this.props.bannerAdSize}
+            adaptiveMode={this.state.enableContainerAdaptiveMode ? "CONTAINER" : "MAIN_SCREEN"}
+            onPaid={(event: PaidEvent) => {
+              console.log(
+                `Paid: ${event.value} ${event.currency} (precision ${RevenuePrecisions[event.precision]
+                }})`,
+              );
+            }}
+          />
+        </View>
+        <Button
+          title="reload"
+          onPress={() => {
+            this.bannerRef.current?.load();
+          }}
+        />
+        <Button
+          title={
+            this.state.enableContainerAdaptiveMode
+              ? "Adapt to main screen"
+              : "Adapt to container"
+          }
+          onPress={() => {
+            this.setState(state => ({
+              enableContainerAdaptiveMode: !state.enableContainerAdaptiveMode
+            }))
+          }}
+        />
+      </>
+    )
   }
 }
 

--- a/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeAdView.java
+++ b/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeAdView.java
@@ -5,6 +5,7 @@ import android.widget.FrameLayout;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Using FrameLayout instead of ReactViewGroup
@@ -18,10 +19,14 @@ import java.util.List;
 public class ReactNativeAdView extends FrameLayout {
   private AdRequest request;
   private List<AdSize> sizes;
+  private List<String> rawSizes;
   private String unitId;
   private boolean manualImpressionsEnabled;
   private boolean propsChanged;
   private boolean isFluid;
+  private String adaptiveMode;
+  private int viewWidth = 0;
+  private Consumer<Integer> widthChangedConsumer;
 
   @Override
   public void requestLayout() {
@@ -74,6 +79,14 @@ public class ReactNativeAdView extends FrameLayout {
     return this.sizes;
   }
 
+  public void setRawSizes(List<String> rawSizes) {
+    this.rawSizes = rawSizes;
+  }
+
+  public List<String> getRawSizes() {
+    return this.rawSizes;
+  }
+
   public void setUnitId(String unitId) {
     this.unitId = unitId;
   }
@@ -104,5 +117,34 @@ public class ReactNativeAdView extends FrameLayout {
 
   public boolean getIsFluid() {
     return this.isFluid;
+  }
+
+  public void setAdaptiveMode(String adaptiveMode) {
+    this.adaptiveMode = adaptiveMode;
+  }
+
+  public String getAdaptiveMode() {
+    return this.adaptiveMode;
+  }
+
+  public int getViewWidth() {
+    return this.viewWidth;
+  }
+
+  public void setWidthChangedConsumer(Consumer<Integer> consumer) {
+    this.widthChangedConsumer = consumer;
+  }
+
+  @Override
+  protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+    super.onSizeChanged(w, h, oldw, oldh);
+
+    this.viewWidth = w;
+
+    if (!adaptiveMode.equals("CONTAINER") || widthChangedConsumer == null || w == oldw) {
+      return;
+    }
+
+    widthChangedConsumer.accept(viewWidth);
   }
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.h
@@ -24,13 +24,17 @@
 
 @interface RNGoogleMobileAdsBannerComponent : RCTView <GADBannerViewDelegate, GADAppEventDelegate>
 
+@property CGFloat viewWidth;
+
 @property GADBannerView *banner;
 @property(nonatomic, assign) BOOL requested;
 
+@property(nonatomic, copy) NSArray *rawSizes;
 @property(nonatomic, copy) NSArray *sizes;
 @property(nonatomic, copy) NSString *unitId;
 @property(nonatomic, copy) NSDictionary *request;
 @property(nonatomic, copy) NSNumber *manualImpressionsEnabled;
+@property(nonatomic, copy) NSString *adaptiveMode;
 @property(nonatomic, assign) BOOL propsChanged;
 
 @property(nonatomic, copy) RCTBubblingEventBlock onNativeEvent;

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerView.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerView.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNGoogleMobileAdsBannerView
     : RCTViewComponentView <GADBannerViewDelegate, GADAppEventDelegate>
 
+@property CGFloat viewWidth;
+
 @property GADBannerView *banner;
 @property(nonatomic, assign) BOOL requested;
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerViewManager.mm
@@ -39,6 +39,8 @@ RCT_EXPORT_VIEW_PROPERTY(request, NSString);
 
 RCT_EXPORT_VIEW_PROPERTY(manualImpressionsEnabled, BOOL);
 
+RCT_EXPORT_VIEW_PROPERTY(adaptiveMode, NSString);
+
 RCT_EXPORT_VIEW_PROPERTY(onNativeEvent, RCTBubblingEventBlock);
 
 RCT_EXPORT_METHOD(recordManualImpression : (nonnull NSNumber *)reactTag) {

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.h
@@ -34,7 +34,9 @@
               error:(nullable NSDictionary *)error
                data:(nullable NSDictionary *)data;
 
-+ (GADAdSize)stringToAdSize:(NSString *)value;
++ (GADAdSize)stringToAdSize:(NSString *)value
+           withAdaptiveMode:(NSString *)adaptiveMode
+              withViewWidth:(CGFloat)viewWidth;
 
 + (BOOL)isAdManagerUnit:(NSString *)unitId;
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.mm
@@ -162,7 +162,9 @@ NSString *const GOOGLE_MOBILE_ADS_EVENT_REWARDED_EARNED_REWARD = @"rewarded_earn
   [[RNRCTEventEmitter shared] sendEventWithName:event body:payload];
 }
 
-+ (GADAdSize)stringToAdSize:(NSString *)value {
++ (GADAdSize)stringToAdSize:(NSString *)value
+           withAdaptiveMode:(NSString *)adaptiveMode
+              withViewWidth:(CGFloat)viewWidth {
   NSError *error = nil;
   NSRegularExpression *regex =
       [NSRegularExpression regularExpressionWithPattern:@"([0-9]+)x([0-9]+)"
@@ -199,16 +201,16 @@ NSString *const GOOGLE_MOBILE_ADS_EVENT_REWARDED_EARNED_REWARD = @"rewarded_earn
   } else if ([value isEqualToString:@"ADAPTIVE_BANNER"] ||
              [value isEqualToString:@"ANCHORED_ADAPTIVE_BANNER"] ||
              [value isEqualToString:@"INLINE_ADAPTIVE_BANNER"]) {
-    CGRect frame = [[UIScreen mainScreen] bounds];
-    if (@available(iOS 11.0, *)) {
-      frame =
-          UIEdgeInsetsInsetRect(frame, [UIApplication sharedApplication].keyWindow.safeAreaInsets);
+    CGFloat width = viewWidth;
+
+    if ([adaptiveMode isEqualToString:@"MAIN_SCREEN"]) {
+      width = [self getMainScreenWidth];
     }
-    CGFloat viewWidth = frame.size.width;
+
     if ([value isEqualToString:@"INLINE_ADAPTIVE_BANNER"]) {
-      return GADCurrentOrientationInlineAdaptiveBannerAdSizeWithWidth(viewWidth);
+      return GADCurrentOrientationInlineAdaptiveBannerAdSizeWithWidth(width);
     }
-    return GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(viewWidth);
+    return GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(width);
   } else {
     return GADAdSizeBanner;
   }
@@ -230,6 +232,17 @@ NSString *const GOOGLE_MOBILE_ADS_EVENT_REWARDED_EARNED_REWARD = @"rewarded_earn
     presentedController = controller.presentedViewController;
   }
   return controller;
+}
+
++ (CGFloat)getMainScreenWidth {
+  CGRect frame = [[UIScreen mainScreen] bounds];
+
+  if (@available(iOS 11.0, *)) {
+    frame =
+        UIEdgeInsetsInsetRect(frame, [UIApplication sharedApplication].keyWindow.safeAreaInsets);
+  }
+
+  return frame.size.width;
 }
 
 @end

--- a/src/ads/BaseAd.tsx
+++ b/src/ads/BaseAd.tsx
@@ -33,7 +33,18 @@ const sizeRegex = /([0-9]+)x([0-9]+)/;
 export const BaseAd = React.forwardRef<
   React.ElementRef<typeof GoogleMobileAdsBannerView>,
   GAMBannerAdProps
->(({ unitId, sizes, requestOptions, manualImpressionsEnabled, ...props }, ref) => {
+>(
+  (
+    {
+      unitId,
+      sizes,
+      requestOptions,
+      manualImpressionsEnabled,
+      adaptiveMode = 'MAIN_SCREEN',
+      ...props
+    },
+    ref,
+  ) => {
   const [dimensions, setDimensions] = useState<(number | DimensionValue)[]>([0, 0]);
 
   const debouncedSetDimensions = debounce(setDimensions, 100);
@@ -154,7 +165,7 @@ export const BaseAd = React.forwardRef<
     }
   }
 
-  const style = sizes.includes(GAMBannerAdSize.FLUID)
+  const style = shouldAdaptToContainer(sizes, adaptiveMode)
     ? {
         width: '100%' as DimensionValue,
         height: dimensions[1],
@@ -172,8 +183,31 @@ export const BaseAd = React.forwardRef<
       unitId={unitId}
       request={JSON.stringify(validatedRequestOptions)}
       manualImpressionsEnabled={!!manualImpressionsEnabled}
+      adaptiveMode={adaptiveMode}
       onNativeEvent={onNativeEvent}
     />
   );
 });
+
+const shouldAdaptToContainer = (
+  sizes: GAMBannerAdProps['sizes'],
+  adaptiveMode: GAMBannerAdProps['adaptiveMode'],
+) => {
+  if (sizes.includes(GAMBannerAdSize.FLUID)) {
+    return true;
+  }
+
+  if (adaptiveMode === 'MAIN_SCREEN') {
+    return false;
+  }
+
+  const adaptiveSizes: string[] = [
+    GAMBannerAdSize.ANCHORED_ADAPTIVE_BANNER,
+    GAMBannerAdSize.INLINE_ADAPTIVE_BANNER,
+    GAMBannerAdSize.ADAPTIVE_BANNER,
+  ];
+
+  return sizes.some(size => adaptiveSizes.includes(size));
+};
+
 BaseAd.displayName = 'BaseAd';

--- a/src/specs/components/GoogleMobileAdsBannerViewNativeComponent.ts
+++ b/src/specs/components/GoogleMobileAdsBannerViewNativeComponent.ts
@@ -22,6 +22,7 @@ export interface NativeProps extends ViewProps {
   unitId: string;
   request: string;
   manualImpressionsEnabled: boolean;
+  adaptiveMode: string;
   onNativeEvent: BubblingEventHandler<NativeEvent>;
 }
 

--- a/src/types/BannerAdProps.ts
+++ b/src/types/BannerAdProps.ts
@@ -54,6 +54,11 @@ export interface BannerAdProps {
   requestOptions?: RequestOptions;
 
   /**
+   * By default adaptive ad size width is equal to the main screen width.
+   */
+  adaptiveMode?: 'CONTAINER' | 'MAIN_SCREEN';
+
+  /**
    * When an ad has finished loading.
    */
   onAdLoaded?: (dimensions: { width: number; height: number }) => void;


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
In a project I’m working on, I need to apply horizontal padding to adaptive banners for better integration with my app's UI. 

Currently, it's not possible to give adaptive banners a width different from the screen width, as mentioned in the stale issue #287.
If the parent view has a different width, padding, or margin, the banner may not display correctly, and parts of it could be cut off.

This PR adds possibility for adaptive banners to take their container's width, as suggested by @dylancom in https://github.com/invertase/react-native-google-mobile-ads/pull/296#issuecomment-1416857910)

I believe this should be the default behaviour for adaptive banner. but to avoid introducing a breaking change. I added a new prop `adaptiveMode` to enable this functionality:

**- MAIN_SCREEN (default):** Keeps the existing behavior where the banner takes the screen width.
**- CONTAINER:** Allows the adaptive banners to use their container's width, with the ad reloaded when the width changes.
### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
#287
### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->
Allow adaptive banners to use their container's width.
### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [X] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

https://github.com/user-attachments/assets/bc2b54a7-d315-4ebc-afd4-6307beed0066



Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter

🔥
