### PR TITLE
fix: add native ad compatibility layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -554,6 +554,8 @@ GoogleService-Info.plist
 src/version.ts
 RNFBVersion.m
 ReactNativeFirebaseVersion.java
+android/src/codegen/
+ios/RNGoogleMobileAdsSpec/
 
 appPlaygrounds/
 app.playground.js

--- a/RNGoogleMobileAdsSpec.podspec
+++ b/RNGoogleMobileAdsSpec.podspec
@@ -2,11 +2,8 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
-google_mobile_ads_sdk_version = package['sdkVersions']['ios']['googleMobileAds']
-google_ump_sdk_version = package['sdkVersions']['ios']['googleUmp']
-
 Pod::Spec.new do |s|
-  s.name                = "RNGoogleMobileAds"
+  s.name                = "RNGoogleMobileAdsSpec"
 
   s.version             = package["version"]
   s.description         = package["description"]
@@ -20,15 +17,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "12.0"
   s.cocoapods_version   = '>= 1.12.0'
-  s.source_files        = "ios/RNGoogleMobileAds/**/*.{h,m,mm,swift}"
-  s.weak_frameworks     = "AppTrackingTransparency"
-
-  if new_arch_enabled then
-    s.subspec 'RNGoogleMobileAdsSpec' do |ss|
-      ss.module_name  = "RNGoogleMobileAdsSpec"
-      ss.source_files = "ios/RNGoogleMobileAdsSpec/**/*.{h,mm,cpp}"
-    end
-  end
+  s.source_files        = "ios/RNGoogleMobileAdsSpec/**/*.{h,m,mm,swift}"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
@@ -51,32 +40,5 @@ Pod::Spec.new do |s|
       s.dependency "RCTTypeSafety"
       s.dependency "ReactCommon/turbomodule/core"
     end
-  end
-
-  # Other dependencies
-  if defined?($RNGoogleUmpSDKVersion)
-    Pod::UI.puts "#{s.name}: Using user specified Google UMP SDK version '#{$RNGoogleUmpSDKVersion}'"
-    google_ump_sdk_version = $RNGoogleUmpSDKVersion
-  end
-
-  if !ENV['MAC_CATALYST']
-  s.dependency          'GoogleUserMessagingPlatform', google_ump_sdk_version
-  end
-
-  if defined?($RNGoogleMobileAdsSDKVersion)
-    Pod::UI.puts "#{s.name}: Using user specified Google Mobile-Ads SDK version '#{$RNGoogleMobileAdsSDKVersion}'"
-    google_mobile_ads_sdk_version = $RNGoogleMobileAdsSDKVersion
-  end
-
-  # AdMob dependencies
-  if !ENV['MAC_CATALYST']
-  s.dependency          'Google-Mobile-Ads-SDK', google_mobile_ads_sdk_version
-  end
-
-  if defined?($RNGoogleMobileAdsAsStaticFramework)
-    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNGoogleMobileAdsAsStaticFramework}'"
-    s.static_framework = $RNGoogleMobileAdsAsStaticFramework
-  else
-    s.static_framework = false
   end
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -113,6 +113,7 @@ android {
       main {
         if (isNewArchitectureEnabled()) {
           java.srcDirs += ['src/newarch']
+          java.srcDirs += ['src/codegen']
         } else {
           java.srcDirs += ['src/oldarch']
         }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsMediaViewManager.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsMediaViewManager.kt
@@ -27,9 +27,7 @@ import com.facebook.react.viewmanagers.RNGoogleMobileAdsMediaViewManagerDelegate
 import com.facebook.react.viewmanagers.RNGoogleMobileAdsMediaViewManagerInterface
 
 @ReactModule(name = ReactNativeGoogleMobileAdsMediaViewManager.NAME)
-class ReactNativeGoogleMobileAdsMediaViewManager(
-  reactContext: ReactApplicationContext
-) : ViewGroupManager<ReactNativeGoogleMobileAdsMediaView>(reactContext),
+class ReactNativeGoogleMobileAdsMediaViewManager : ViewGroupManager<ReactNativeGoogleMobileAdsMediaView>(),
   RNGoogleMobileAdsMediaViewManagerInterface<ReactNativeGoogleMobileAdsMediaView> {
   private val delegate: ViewManagerDelegate<ReactNativeGoogleMobileAdsMediaView> = RNGoogleMobileAdsMediaViewManagerDelegate(this)
 

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeAdViewManager.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeAdViewManager.kt
@@ -18,7 +18,6 @@ package io.invertase.googlemobileads
  */
 
 import android.view.View
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
@@ -29,9 +28,7 @@ import com.facebook.react.viewmanagers.RNGoogleMobileAdsNativeViewManagerDelegat
 import com.facebook.react.viewmanagers.RNGoogleMobileAdsNativeViewManagerInterface
 
 @ReactModule(name = ReactNativeGoogleMobileAdsNativeAdViewManager.NAME)
-class ReactNativeGoogleMobileAdsNativeAdViewManager(
-  reactContext: ReactApplicationContext
-) : ViewGroupManager<ReactNativeGoogleMobileAdsNativeAdView>(reactContext),
+class ReactNativeGoogleMobileAdsNativeAdViewManager : ViewGroupManager<ReactNativeGoogleMobileAdsNativeAdView>(),
   RNGoogleMobileAdsNativeViewManagerInterface<ReactNativeGoogleMobileAdsNativeAdView> {
   private val delegate: ViewManagerDelegate<ReactNativeGoogleMobileAdsNativeAdView> = RNGoogleMobileAdsNativeViewManagerDelegate(this)
 

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsPackage.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsPackage.kt
@@ -31,8 +31,8 @@ class ReactNativeGoogleMobileAdsPackage : TurboReactPackage() {
   ): List<ViewManager<*, *>> {
     return listOf(
       ReactNativeGoogleMobileAdsBannerAdViewManager(),
-      ReactNativeGoogleMobileAdsNativeAdViewManager(reactContext),
-      ReactNativeGoogleMobileAdsMediaViewManager(reactContext)
+      ReactNativeGoogleMobileAdsNativeAdViewManager(),
+      ReactNativeGoogleMobileAdsMediaViewManager()
     )
   }
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.h
@@ -21,7 +21,7 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#import <RNGoogleMobileAdsSpec/RNGoogleMobileAdsSpec.h>
+#import <RNGoogleMobileAds/RNGoogleMobileAdsSpec.h>
 @interface RNGoogleMobileAdsAppOpenModule : NSObject <NativeAppOpenModuleSpec>
 
 #else

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsAppOpenModule.mm
@@ -19,9 +19,6 @@
 
 #import "RNGoogleMobileAdsAppOpenModule.h"
 #import <GoogleMobileAds/GoogleMobileAds.h>
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNGoogleMobileAdsSpec.h"
-#endif
 #import "RNGoogleMobileAdsCommon.h"
 #import "RNGoogleMobileAdsFullScreenAd.h"
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerView.mm
@@ -5,10 +5,10 @@
 #import "RNGoogleMobileAdsBannerView.h"
 #import "RNGoogleMobileAdsCommon.h"
 
-#import <react/renderer/components/RNGoogleMobileAdsSpec/ComponentDescriptors.h>
-#import <react/renderer/components/RNGoogleMobileAdsSpec/EventEmitters.h>
-#import <react/renderer/components/RNGoogleMobileAdsSpec/Props.h>
-#import <react/renderer/components/RNGoogleMobileAdsSpec/RCTComponentViewHelpers.h>
+#import <RNGoogleMobileAds/ComponentDescriptors.h>
+#import <RNGoogleMobileAds/EventEmitters.h>
+#import <RNGoogleMobileAds/Props.h>
+#import <RNGoogleMobileAds/RCTComponentViewHelpers.h>
 
 #import "RCTFabricComponentsPlugins.h"
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.h
@@ -21,7 +21,7 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#import <RNGoogleMobileAdsSpec/RNGoogleMobileAdsSpec.h>
+#import <RNGoogleMobileAds/RNGoogleMobileAdsSpec.h>
 @interface RNGoogleMobileAdsConsentModule : NSObject <NativeConsentModuleSpec>
 
 #else

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsConsentModule.mm
@@ -22,9 +22,6 @@
 #if !TARGET_OS_MACCATALYST
 #include <UserMessagingPlatform/UserMessagingPlatform.h>
 #endif
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNGoogleMobileAdsSpec.h"
-#endif
 #import "RNGoogleMobileAdsConsentModule.h"
 #import "common/RNSharedUtils.h"
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.h
@@ -21,7 +21,7 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#import <RNGoogleMobileAdsSpec/RNGoogleMobileAdsSpec.h>
+#import <RNGoogleMobileAds/RNGoogleMobileAdsSpec.h>
 @interface RNGoogleMobileAdsInterstitialModule : NSObject <NativeInterstitialModuleSpec>
 
 #else

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsInterstitialModule.mm
@@ -19,9 +19,6 @@
 
 #import "RNGoogleMobileAdsInterstitialModule.h"
 #import <GoogleMobileAds/GoogleMobileAds.h>
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNGoogleMobileAdsSpec.h"
-#endif
 #import "RNGoogleMobileAdsCommon.h"
 #import "RNGoogleMobileAdsFullScreenAd.h"
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
@@ -19,10 +19,10 @@
 #import "RNGoogleMobileAdsNativeModule.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
-#import <react/renderer/components/RNGoogleMobileAdsSpec/ComponentDescriptors.h>
-#import <react/renderer/components/RNGoogleMobileAdsSpec/EventEmitters.h>
-#import <react/renderer/components/RNGoogleMobileAdsSpec/Props.h>
-#import <react/renderer/components/RNGoogleMobileAdsSpec/RCTComponentViewHelpers.h>
+#import <RNGoogleMobileAds/ComponentDescriptors.h>
+#import <RNGoogleMobileAds/EventEmitters.h>
+#import <RNGoogleMobileAds/Props.h>
+#import <RNGoogleMobileAds/RCTComponentViewHelpers.h>
 
 #import "RCTFabricComponentsPlugins.h"
 #endif

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsModule.h
@@ -19,7 +19,7 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#import <RNGoogleMobileAdsSpec/RNGoogleMobileAdsSpec.h>
+#import <RNGoogleMobileAds/RNGoogleMobileAdsSpec.h>
 @interface RNGoogleMobileAdsModule : NSObject <NativeGoogleMobileAdsModuleSpec>
 
 #else

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsModule.mm
@@ -21,9 +21,6 @@
 #import <React/RCTUtils.h>
 
 #import "RNGoogleMobileAdsModule.h"
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNGoogleMobileAdsSpec.h"
-#endif
 #import "common/RNSharedUtils.h"
 
 @implementation RNGoogleMobileAdsModule

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.h
@@ -19,7 +19,7 @@
 #import <GoogleMobileAds/GADNativeAd.h>
 
 #ifdef RCT_NEW_ARCH_ENABLED
-#import <RNGoogleMobileAdsSpec/RNGoogleMobileAdsSpec.h>
+#import <RNGoogleMobileAds/RNGoogleMobileAdsSpec.h>
 
 @interface RNGoogleMobileAdsNativeModule
     : NativeGoogleMobileAdsNativeModuleSpecBase <NativeGoogleMobileAdsNativeModuleSpec>

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
@@ -20,10 +20,10 @@
 #import "RNGoogleMobileAdsNativeModule.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
-#import <react/renderer/components/RNGoogleMobileAdsSpec/ComponentDescriptors.h>
-#import <react/renderer/components/RNGoogleMobileAdsSpec/EventEmitters.h>
-#import <react/renderer/components/RNGoogleMobileAdsSpec/Props.h>
-#import <react/renderer/components/RNGoogleMobileAdsSpec/RCTComponentViewHelpers.h>
+#import <RNGoogleMobileAds/ComponentDescriptors.h>
+#import <RNGoogleMobileAds/EventEmitters.h>
+#import <RNGoogleMobileAds/Props.h>
+#import <RNGoogleMobileAds/RCTComponentViewHelpers.h>
 
 #import "RCTFabricComponentsPlugins.h"
 #endif

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedInterstitialModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedInterstitialModule.h
@@ -21,7 +21,7 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#import <RNGoogleMobileAdsSpec/RNGoogleMobileAdsSpec.h>
+#import <RNGoogleMobileAds/RNGoogleMobileAdsSpec.h>
 @interface RNGoogleMobileAdsRewardedInterstitialModule
     : NSObject <NativeRewardedInterstitialModuleSpec>
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedInterstitialModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedInterstitialModule.mm
@@ -19,9 +19,6 @@
 
 #import "RNGoogleMobileAdsRewardedInterstitialModule.h"
 #import <GoogleMobileAds/GoogleMobileAds.h>
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNGoogleMobileAdsSpec.h"
-#endif
 #import "RNGoogleMobileAdsCommon.h"
 #import "RNGoogleMobileAdsFullScreenAd.h"
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.h
@@ -21,7 +21,7 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#import <RNGoogleMobileAdsSpec/RNGoogleMobileAdsSpec.h>
+#import <RNGoogleMobileAds/RNGoogleMobileAdsSpec.h>
 @interface RNGoogleMobileAdsRewardedModule : NSObject <NativeRewardedModuleSpec>
 
 #else

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsRewardedModule.mm
@@ -19,9 +19,6 @@
 
 #import "RNGoogleMobileAdsRewardedModule.h"
 #import <GoogleMobileAds/GoogleMobileAds.h>
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNGoogleMobileAdsSpec.h"
-#endif
 #import "RNGoogleMobileAdsCommon.h"
 #import "RNGoogleMobileAdsFullScreenAd.h"
 

--- a/package.json
+++ b/package.json
@@ -66,9 +66,12 @@
   },
   "scripts": {
     "prepare": "yarn build && yarn build:plugin",
-    "build": "genversion --es6 --semi src/version.ts && bob build",
+    "build": "genversion --es6 --semi src/version.ts && bob build && yarn codegen",
     "build:clean": "rimraf android/build && rimraf ios/build && rimraf lib && rimraf plugin/build",
     "build:plugin": "yarn tsc --build plugin",
+    "codegen": "yarn codegen:android && yarn codegen:ios",
+    "codegen:android": "npx --yes @react-native-community/cli codegen --platform android --outputPath android/src/codegen",
+    "codegen:ios": "npx --yes @react-native-community/cli codegen --platform ios --outputPath ios/RNGoogleMobileAdsSpec",
     "lint:code": "yarn lint:js && yarn lint:android && yarn lint:ios:check",
     "lint:js": "eslint src/ --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "lint:android": "google-java-format --set-exit-if-changed --replace --glob=\"android/**/*.java\"",
@@ -169,6 +172,7 @@
     "name": "RNGoogleMobileAdsSpec",
     "type": "all",
     "jsSrcsDir": "./src/specs",
+    "includesGeneratedCode": true,
     "android": {
       "javaPackageName": "io.invertase.googlemobileads"
     }


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Updated codes to include generated native code by codegen(Reference: https://reactnative.dev/docs/the-new-architecture/codegen-cli#including-generated-code-into-libraries). By doing this, as the generated code is always included in npm artifact(and not rely on the app to run codegen for us), we can support lower react native(or @react-native/codegen) version.

Also removed unnecessary constructor passing contexts in classes extending ViewGroupManager, which breaks build in rn version lower than 0.75.

Fixes #678
### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
