### PR TITLE
fix(ios): register asset view properly in old arch

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
@@ -127,7 +127,12 @@ using namespace facebook::react;
 - (void)registerAsset:(NSString *)assetType reactTag:(NSInteger)reactTag {
   RCTExecuteOnMainQueue(^{
     UIView *view = [_bridge.uiManager viewForReactTag:@(reactTag)];
-
+    if (!view) {
+      RCTLogError(@"Cannot find NativeAssetView with tag #%zd while registering asset type %@",
+                  reactTag, assetType);
+      return;
+    }
+    
     if ([assetType isEqual:@"media"] && [view isKindOfClass:RNGoogleMobileAdsMediaView.class]) {
 #ifdef RCT_NEW_ARCH_ENABLED
       GADMediaView *mediaView = ((RNGoogleMobileAdsMediaView *)view).contentView;
@@ -194,9 +199,9 @@ RCT_EXPORT_VIEW_PROPERTY(responseId, NSString)
 }
 
 RCT_EXPORT_METHOD(registerAsset
-                  : (nonnull NSNumber *)reactTag commandID
-                  : (NSInteger)commandID commandArgs
-                  : (NSArray<id> *)commandArgs) {
+                  : (nonnull NSNumber *)reactTag assetType
+                  : (nonnull NSString *)assetType assetReactTag
+                  : (nonnull NSNumber *)assetReactTag) {
   [self.bridge.uiManager
       addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
         RNGoogleMobileAdsNativeView *view = viewRegistry[reactTag];
@@ -204,7 +209,7 @@ RCT_EXPORT_METHOD(registerAsset
           RCTLogError(@"Cannot find NativeView with tag #%@", reactTag);
           return;
         }
-        [view registerAsset:commandArgs[0] reactTag:((NSNumber *)commandArgs[1]).intValue];
+        [view registerAsset:assetType reactTag:assetReactTag.intValue];
       }];
 }
 #endif

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
@@ -132,7 +132,7 @@ using namespace facebook::react;
                   reactTag, assetType);
       return;
     }
-    
+
     if ([assetType isEqual:@"media"] && [view isKindOfClass:RNGoogleMobileAdsMediaView.class]) {
 #ifdef RCT_NEW_ARCH_ENABLED
       GADMediaView *mediaView = ((RNGoogleMobileAdsMediaView *)view).contentView;


### PR DESCRIPTION
### Description

Somehow I implemented the logic for registering the native asset view in iOS (old architecture) incorrectly.
This caused the native assets to not respond to clicks, and issues showed up in the Native Ad Validator.

### Related issues

Fixes #685, fixes #694

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
