### PR TITLE
ci: use @react-native-community/cli init

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -65,7 +65,7 @@ jobs:
           mv *tgz $HOME/scratch
           ls -la $HOME/scratch/*$CLEAN_PACKAGE_NAME*
           cd $HOME
-          npx react-native init template --skip-install --skip-git-init
+          npx @react-native-community/cli init template --skip-install --skip-git-init
           cd template
           yarn
           yarn add patch-package --dev


### PR DESCRIPTION
### Description

Uses `@react-native-community/cli init` in create test patch workflow as `react-native init` is removed.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
