### PR TITLE
fix(iOS): prevent crash when nativeAd.icon is missing

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
@@ -95,9 +95,12 @@ RCT_EXPORT_METHOD(
           @"price" : nativeAd.price ?: [NSNull null],
           @"store" : nativeAd.store ?: [NSNull null],
           @"starRating" : nativeAd.starRating ?: [NSNull null],
-          @"icon" : nativeAd.icon != nil
-              ? @{@"scale" : @(nativeAd.icon.scale), @"url" : nativeAd.icon.imageURL.absoluteString}
-              : [NSNull null],
+          @"icon" : (nativeAd.icon && nativeAd.icon.imageURL && nativeAd.icon.imageURL.absoluteString)
+            ? @{
+                @"url" : nativeAd.icon.imageURL.absoluteString,
+                @"scale" : nativeAd.icon.scale ? @(nativeAd.icon.scale) : @1
+              }
+            : [NSNull null],
           @"mediaContent" : @{
             @"aspectRatio" : @(nativeAd.mediaContent.aspectRatio),
             @"hasVideoContent" : @(nativeAd.mediaContent.hasVideoContent),


### PR DESCRIPTION
# **Pull Request: Ensure Safe Handling of `nativeAd.icon` to Prevent Crashes from Missing Mediation Data**

## **Description**  

This PR improves the safety of handling `nativeAd.icon` to prevent crashes caused by missing mediation data.  
- Some mediation networks do not provide an `icon` value, which previously led to crashes.  
- Ensures `nativeAd.icon.imageURL.absoluteString` is only accessed if all necessary properties exist.  
- Defaults `scale` to `1` if `nativeAd.icon.scale` is `nil`, ensuring predictable behavior.  
- If no valid `icon` is provided, the entire `icon` field is set to `[NSNull null]` to maintain data consistency.  

This update improves the stability of handling native ads across different mediation networks.

---

## **Related issues**  

N/A  

---

## **Release Summary**  

Fixes a crash caused by missing `icon` values in some mediation networks.

---

## **Checklist**  

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)  
  - [x] Yes  
- My change supports the following platforms:  
  - [x] `iOS`  
  - [ ] `Android`  
- My change includes tests:  
  - [ ] `e2e` tests added or updated in `__tests__e2e__`  
  - [ ] `jest` tests added or updated in `__tests__`  
- [ ] I have updated TypeScript types that are affected by my change.  
- This is a breaking change:  
  - [ ] Yes  
  - [x] No  