### PR TITLE
feat(android): Add isTestDevice() to detect test ads

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.kt
@@ -179,6 +179,17 @@ class ReactNativeGoogleMobileAdsModule(
     MobileAds.setAppMuted(muted)
   }
 
+  @ReactMethod
+  fun isTestDevice(promise: Promise) {
+      try {
+          val adRequest = AdRequest.Builder().build()
+          val isTest = adRequest.isTestDevice(reactApplicationContext)
+          promise.resolve(isTest)
+      } catch (e: Exception) {
+          promise.reject("ERROR_CHECKING_TEST_DEVICE", e.message)
+      }
+  }
+
   companion object {
     const val NAME = "RNGoogleMobileAdsModule"
   }

--- a/src/MobileAds.ts
+++ b/src/MobileAds.ts
@@ -68,6 +68,10 @@ class MobileAdsModule implements MobileAdsModuleInterface {
   setAppMuted(muted: boolean) {
     RNGoogleMobileAdsModule.setAppMuted(muted);
   }
+
+  isTestDevice(): Promise<boolean> {
+    return RNGoogleMobileAdsModule.isTestDevice();
+  }
 }
 
 const MobileAdsInstance = new MobileAdsModule();

--- a/src/specs/modules/NativeGoogleMobileAdsModule.ts
+++ b/src/specs/modules/NativeGoogleMobileAdsModule.ts
@@ -35,6 +35,7 @@ export interface Spec extends TurboModule {
   openDebugMenu(adUnit: string): void;
   setAppVolume(volume: number): void;
   setAppMuted(muted: boolean): void;
+  isTestDevice(): Promise<boolean>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNGoogleMobileAdsModule');


### PR DESCRIPTION
### Description

This PR introduces a new method `isTestDevice()` for **AdMob in Android**, allowing developers to check if a device is flagged as a **Test Device**.

### **Why is this needed?**
- Some users unknowingly enable **"Enable debug logging for ads"** in **Developer Options**, which forces **test ads** (fake ads).
- When test ads are served, AdMob sets `user_id` to `"fakeForAdDebugLog"` in **Server-Side Verification (SSV) callbacks**, causing rewards to **not be granted**.
  - **Reference**: [Stack Overflow - `fakeForAdDebugLog` on SSV](https://stackoverflow.com/questions/64396379/fakeforaddebuglog-on-serversideverification-for-admob-rewardedad)
- As a result, users frequently complain:  
  > "I watched the ad but did not receive the reward."

### **How this PR helps**
- With `isTestDevice()`, developers can **detect Test Devices and take action**, such as:
  - **Disabling rewarded ads** for Test Devices.
  - **Showing a warning message** to users explaining why rewards won't be granted.
  - **Logging the issue** for debugging purposes.

- **Google’s documentation confirms this behavior:**  
  - [AdMob Debug Logging](https://developers.google.com/admob/android/network-tracing) explains that **debug logging forces test ads**, which **cannot pass SSV validation**.

### Related issues
<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary
<!-- An optional description that you want to appear on the generated changelog -->
- **Added a new method**: `isTestDevice()`
- **Exposed this method via**:
  - **Native Android (Kotlin)**
  - **TurboModule (TypeScript)**
  - **React Native wrapper (`MobileAds.ts`)**

### Checklist
- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan
<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
- **Called `MobileAds().isTestDevice()`** in a test app.
- **Verified the result matches AdMob’s `isTestDevice()` function.**
- **Ensured the API is properly exposed** in React Native and callable from JavaScript.
- **Checked logs** to confirm correct detection of Test Devices.
- 
---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:
- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
