### PR TITLE
Fix enum bindings

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeModule.kt
@@ -145,8 +145,8 @@ class ReactNativeGoogleMobileAdsNativeModule(
       val mediaAspectRatio = if (requestOptions.hasKey("aspectRatio")) {
         when (requestOptions.getInt("aspectRatio")) {
           1 -> MediaAspectRatio.ANY
-          2 -> MediaAspectRatio.PORTRAIT
-          3 -> MediaAspectRatio.LANDSCAPE
+          2 -> MediaAspectRatio.LANDSCAPE
+          3 -> MediaAspectRatio.PORTRAIT
           4 -> MediaAspectRatio.SQUARE
           else -> MediaAspectRatio.UNKNOWN
         }
@@ -155,8 +155,8 @@ class ReactNativeGoogleMobileAdsNativeModule(
       }
       val adChoicesPlacement = if (requestOptions.hasKey("adChoicesPlacement")) {
         when (requestOptions.getInt("adChoicesPlacement")) {
-          0 -> NativeAdOptions.ADCHOICES_TOP_RIGHT
-          1 -> NativeAdOptions.ADCHOICES_TOP_LEFT
+          0 -> NativeAdOptions.ADCHOICES_TOP_LEFT
+          1 -> NativeAdOptions.ADCHOICES_TOP_RIGHT
           2 -> NativeAdOptions.ADCHOICES_BOTTOM_RIGHT
           3 -> NativeAdOptions.ADCHOICES_BOTTOM_LEFT
           else -> NativeAdOptions.ADCHOICES_TOP_RIGHT
@@ -169,8 +169,14 @@ class ReactNativeGoogleMobileAdsNativeModule(
       } else {
         true
       }
+      val customControlsRequested = if (requestOptions.hasKey("customControlsRequested")) {
+        requestOptions.getBoolean("customControlsRequested")
+      } else {
+        false
+      }
       val videoOptions = VideoOptions.Builder()
         .setStartMuted(startVideoMuted)
+        .setCustomControlsRequested(customControlsRequested)
         .build()
       val nativeAdOptions = NativeAdOptions.Builder()
 //      .setReturnUrlsForImageAssets(true)

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
@@ -162,8 +162,8 @@ RCT_EXPORT_METHOD(destroy
       }
     }
     GADNativeAdViewAdOptions *adViewOptions = [[GADNativeAdViewAdOptions alloc] init];
-    if (requestOptions[@"aspectRatio"]) {
-      switch ([requestOptions[@"aspectRatio"] intValue]) {
+    if (requestOptions[@"adChoicesPlacement"]) {
+      switch ([requestOptions[@"adChoicesPlacement"] intValue]) {
         case 0:
           adViewOptions.preferredAdChoicesPosition = GADAdChoicesPositionTopLeftCorner;
           break;
@@ -181,6 +181,9 @@ RCT_EXPORT_METHOD(destroy
     GADVideoOptions *videoOptions = [[GADVideoOptions alloc] init];
     if (requestOptions[@"startVideoMuted"]) {
       videoOptions.startMuted = [requestOptions[@"startVideoMuted"] boolValue];
+    }
+    if (requestOptions[@"customControlsRequested"]) {
+      videoOptions.customControlsRequested = [requestOptions[@"customControlsRequested"] boolValue];
     }
 
     _adLoader = [[GADAdLoader alloc]

--- a/src/common/validate.ts
+++ b/src/common/validate.ts
@@ -105,3 +105,7 @@ export function isOneOf(value: unknown, oneOf: unknown[] = []) {
   }
   return oneOf.includes(value);
 }
+
+export function isNumber(value: unknown) {
+  return typeof value === 'number';
+}

--- a/src/types/NativeAdRequestOptions.ts
+++ b/src/types/NativeAdRequestOptions.ts
@@ -52,4 +52,12 @@ export interface NativeAdRequestOptions extends RequestOptions {
    * - When enabled, your app requests that the video should begin with audio muted.
    */
   startVideoMuted?: boolean;
+
+  /**
+   * Disables or enables the custom controls for the video.
+   * - The custom controls are enabled by default.
+   * - When disabled, your app requests that the video should not have custom controls.
+   * - When enabled, your app requests that the video should have custom controls.
+   */
+  customControlsRequested?: boolean;
 }

--- a/src/validateAdRequestOptions.ts
+++ b/src/validateAdRequestOptions.ts
@@ -23,12 +23,14 @@ import {
   isString,
   isUndefined,
   isValidUrl,
+  isNumber,
 } from './common';
 import { version } from './version';
 import { RequestOptions } from './types/RequestOptions';
+import { NativeAdRequestOptions } from './types/NativeAdRequestOptions';
 
-export function validateAdRequestOptions(options?: RequestOptions) {
-  const out: RequestOptions = {
+export function validateAdRequestOptions(options?: RequestOptions & NativeAdRequestOptions) {
+  const out: RequestOptions & NativeAdRequestOptions = {
     requestAgent: `rn-invertase-${version}`,
   };
 
@@ -134,6 +136,34 @@ export function validateAdRequestOptions(options?: RequestOptions) {
       throw new Error("'options.publisherProvidedId' expected a string value");
     }
     out.publisherProvidedId = options.publisherProvidedId;
+  }
+
+  if (!isUndefined(options?.adChoicesPlacement)) {
+    if (!isNumber(options.adChoicesPlacement)) {
+      throw new Error("'options.adChoicesPlacement' expected a number value");
+    }
+    out.adChoicesPlacement = options.adChoicesPlacement;
+  }
+
+  if (!isUndefined(options?.aspectRatio)) {
+    if (!isNumber(options.aspectRatio)) {
+      throw new Error("'options.aspectRatio' expected a number value");
+    }
+    out.aspectRatio = options.aspectRatio;
+  }
+
+  if (!isUndefined(options?.startVideoMuted)) {
+    if (!isBoolean(options.startVideoMuted)) {
+      throw new Error("'options.startVideoMuted' expected a boolean value");
+    }
+    out.startVideoMuted = options.startVideoMuted;
+  }
+
+  if (!isUndefined(options?.customControlsRequested)) {
+    if (!isBoolean(options.customControlsRequested)) {
+      throw new Error("'options.customControlsRequested' expected a boolean value");
+    }
+    out.customControlsRequested = options.customControlsRequested;
   }
 
   return out;


### PR DESCRIPTION
Fix enum bindings on android, fix wrong property being extracted on iOS, pass values specified in documentation to the native side, add customControlsRequested prop

### Description

The code does not work as it is specified in the documentation, the request option params are ignored

### Related issues

This PR fixes https://github.com/invertase/react-native-google-mobile-ads/issues/703

### Release Summary

- Fix enum bindings on android;
- Fix wrong property being extracted on iOS;
- Pass values specified in documentation to the native side;
- Add customControlsRequested prop.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No