### PR TITLE
fix(nativeview, ios): use correct prop type for NativeView

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
@@ -52,7 +52,7 @@ using namespace facebook::react;
 
 - (instancetype)initWithFrame:(CGRect)frame {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsBannerViewProps>();
+    static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsNativeViewProps>();
     _props = defaultProps;
 
     _bridge = [RCTBridge currentBridge];


### PR DESCRIPTION
### Description

The NativeView was previously using the banner prop type (RNGoogleMobileAdsBannerViewProps) in `initWithFrame`.
While this is currently identical to the nativead prop and causes no functional issues, it could lead to problems in the future if the two props diverge.

This change updates the prop type to ensure consistency and prevent potential issues down the line.

### Related issues

### Release Summary

Updated `NativeView` to use the correct native view prop type.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
