### PR TITLE
fix: Fabric codegen support for new arch

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
@@ -129,21 +129,22 @@ using namespace facebook::react;
 
 @end
 
+#ifndef RCT_NEW_ARCH_ENABLED
+
 @implementation RNGoogleMobileAdsMediaViewManager
 
 RCT_EXPORT_MODULE(RNGoogleMobileAdsMediaView)
 
 RCT_EXPORT_VIEW_PROPERTY(responseId, NSString)
-
 RCT_EXPORT_VIEW_PROPERTY(resizeMode, NSString)
 
-#ifndef RCT_NEW_ARCH_ENABLED
 - (UIView *)view {
   return [[RNGoogleMobileAdsMediaView alloc] initWithBridge:self.bridge];
 }
-#endif
 
 @end
+
+#endif
 
 #ifdef RCT_NEW_ARCH_ENABLED
 Class<RCTComponentViewProtocol> RNGoogleMobileAdsMediaViewCls(void) {

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
@@ -187,13 +187,17 @@ using namespace facebook::react;
 
 @end
 
+#ifndef RCT_NEW_ARCH_ENABLED
+
+@interface RNGoogleMobileAdsNativeViewManager : RCTViewManager
+@end
+
 @implementation RNGoogleMobileAdsNativeViewManager
 
 RCT_EXPORT_MODULE(RNGoogleMobileAdsNativeView)
 
 RCT_EXPORT_VIEW_PROPERTY(responseId, NSString)
 
-#ifndef RCT_NEW_ARCH_ENABLED
 - (UIView *)view {
   return [[RNGoogleMobileAdsNativeView alloc] initWithBridge:self.bridge];
 }
@@ -212,9 +216,10 @@ RCT_EXPORT_METHOD(registerAsset
         [view registerAsset:assetType reactTag:assetReactTag.intValue];
       }];
 }
-#endif
 
 @end
+
+#endif
 
 #ifdef RCT_NEW_ARCH_ENABLED
 Class<RCTComponentViewProtocol> RNGoogleMobileAdsNativeViewCls(void) {

--- a/package.json
+++ b/package.json
@@ -169,6 +169,12 @@
     "name": "RNGoogleMobileAdsSpec",
     "type": "all",
     "jsSrcsDir": "./src/specs",
+    "ios": {
+      "componentProvider": {
+        "RNGoogleMobileAdsNativeView": "RNGoogleMobileAdsNativeView",
+        "RNGoogleMobileAdsMediaView": "RNGoogleMobileAdsMediaView"
+      }
+    },
     "android": {
       "javaPackageName": "io.invertase.googlemobileads"
     }


### PR DESCRIPTION
### Description
The native ad components were incorrectly implemented for React Native 0.81 with the new architecture enabled. Legacy components were being used, which [caused a crash](https://github.com/invertase/react-native-google-mobile-ads/issues/777) in recent versions. This PR fixes that crash by correcting the codegen and editing the native code so that `ViewManager` (legacy) implementations are only used for the old architecture.

### Related issues

Fixes #777 

### Release Summary

- Corrects native ad component implementation for RN 0.81 with new architecture.
- Ensures compatibility with both legacy and new Fabric architectures on iOS.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `iOS`

### Test Plan

- Verified that the app no longer crashes on iOS.
- All native ad components display correctly, including the AdMob native ad validator.

<img width="300" height="323" alt="image" src="https://github.com/user-attachments/assets/d747e24f-3ee5-4b61-aae3-ce77eeba20ad" />
