### PR TITLE
feat(banner): Add onAdImpression and onAdClicked event listeners

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -287,7 +287,7 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
           }
 
           @Override
-          public void onAdImpression {
+          public void onAdImpression() {
             sendEvent(reactViewGroup, EVENT_AD_IMPRESSION, null);
           }
 

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -292,7 +292,7 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
           }
 
           @Override
-          public void onAdClicked {
+          public void onAdClicked() {
             sendEvent(reactViewGroup, EVENT_AD_CLICKED, null);
           }
         });

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -57,6 +57,8 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
     extends SimpleViewManager<ReactNativeAdView> {
   private static final String REACT_CLASS = "RNGoogleMobileAdsBannerView";
   private final String EVENT_AD_LOADED = "onAdLoaded";
+  private final String EVENT_AD_IMPRESSION = "onAdImpression";
+  private final String EVENT_AD_CLICKED = "onAdClicked";
   private final String EVENT_AD_FAILED_TO_LOAD = "onAdFailedToLoad";
   private final String EVENT_AD_OPENED = "onAdOpened";
   private final String EVENT_AD_CLOSED = "onAdClosed";
@@ -282,6 +284,16 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
           @Override
           public void onAdClosed() {
             sendEvent(reactViewGroup, EVENT_AD_CLOSED, null);
+          }
+
+          @Override
+          public void onAdImpression {
+            sendEvent(reactViewGroup, EVENT_AD_IMPRESSION, null);
+          }
+
+          @Override
+          public void onAdClicked {
+            sendEvent(reactViewGroup, EVENT_AD_CLICKED, null);
           }
         });
     if (adView instanceof AdManagerAdView) {

--- a/docs/displaying-ads.mdx
+++ b/docs/displaying-ads.mdx
@@ -456,6 +456,8 @@ or network triggers an event:
 - `onAdFailedToLoad`
 - `onAdLeftApplication`
 - `onAdOpened`
+- `onAdImpression`
+- `onAdClicked`
 - `onPaid` &mdash; On [impression-level ad revenue](https://support.google.com/admob/answer/11322405?hl=en) events.
 
 Each render of the component loads a single advert, allowing you to display multiple adverts at once. If you need to reload/change

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.m
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerComponent.m
@@ -184,6 +184,14 @@
   [self sendEvent:@"onAdOpened" payload:nil];
 }
 
+- (void)bannerViewDidRecordImpression:(GADBannerView *)bannerView {
+  [self sendEvent:@"onAdImpression" payload:nil];
+}
+
+- (void)bannerViewDidRecordClick:(GADBannerView *)bannerView {
+  [self sendEvent:@"onAdClicked" payload:nil];
+}
+
 - (void)bannerViewWillDismissScreen:(GADBannerView *)bannerView {
   // not in use
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerView.mm
@@ -225,6 +225,25 @@ using namespace facebook::react;
   }
 }
 
+- (void)bannerViewDidRecordImpression:(GADBannerView *)bannerView {
+  if (_eventEmitter != nullptr) {
+    std::dynamic_pointer_cast<const facebook::react::RNGoogleMobileAdsBannerViewEventEmitter>(
+        _eventEmitter)
+        ->onNativeEvent(facebook::react::RNGoogleMobileAdsBannerViewEventEmitter::OnNativeEvent{
+            .type = "onAdImpression"});
+  }
+}
+
+- (void)bannerViewDidRecordClick:(GADBannerView *)bannerView {
+  if (_eventEmitter != nullptr) {
+    std::dynamic_pointer_cast<const facebook::react::RNGoogleMobileAdsBannerViewEventEmitter>(
+        _eventEmitter)
+        ->onNativeEvent(facebook::react::RNGoogleMobileAdsBannerViewEventEmitter::OnNativeEvent{
+            .type = "onAdClicked"});
+  }
+}
+
+
 - (void)bannerViewWillDismissScreen:(GADBannerView *)bannerView {
   // not in use
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsBannerView.mm
@@ -243,7 +243,6 @@ using namespace facebook::react;
   }
 }
 
-
 - (void)bannerViewWillDismissScreen:(GADBannerView *)bannerView {
   // not in use
 }

--- a/src/ads/BaseAd.tsx
+++ b/src/ads/BaseAd.tsx
@@ -79,7 +79,7 @@ export const BaseAd = React.forwardRef<
             width: number;
             height: number;
           }
-        | { type: 'onAdOpened' | 'onAdClosed' }
+        | { type: 'onAdOpened' | 'onAdClosed' | 'onAdImpression' | 'onAdClicked' }
         | {
             type: 'onAdFailedToLoad';
             code: string;

--- a/src/types/BannerAdProps.ts
+++ b/src/types/BannerAdProps.ts
@@ -81,6 +81,16 @@ export interface BannerAdProps {
   onAdOpened?: () => void;
 
   /**
+   * Called when an impression is recorded for an ad.
+   */
+  onAdImpression?: () => void;
+
+  /**
+   * Called when a click is recorded for an ad
+   */
+  onAdClicked?: () => void;
+
+  /**
    * Called when the user is about to return to the app after tapping on an ad.
    */
   onAdClosed?: () => void;


### PR DESCRIPTION
### Description

Add onAdImpression and onAdClicked event listeners for Banner Ads

### Related issues

Fixes #794

### Release Summary

- Add onAdImpression and onAdClicked event listeners for Banner Ads

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

:fire: