### PR TITLE
fix(native ad, ios): fixed ios crash

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
@@ -96,8 +96,8 @@ RCT_EXPORT_METHOD(
           @"store" : nativeAd.store ?: [NSNull null],
           @"starRating" : nativeAd.starRating ?: [NSNull null],
           @"icon" : (nativeAd.icon && nativeAd.icon.imageURL != nil)
-            ? @{@"scale": @(nativeAd.icon.scale), @"url": nativeAd.icon.imageURL.absoluteString}
-            : [NSNull null],
+              ? @{@"scale" : @(nativeAd.icon.scale), @"url" : nativeAd.icon.imageURL.absoluteString}
+              : [NSNull null],
           @"mediaContent" : @{
             @"aspectRatio" : @(nativeAd.mediaContent.aspectRatio),
             @"hasVideoContent" : @(nativeAd.mediaContent.hasVideoContent),


### PR DESCRIPTION
### Description

This PR fixes an `NSInvalidArgumentException` error (`attempt to insert nil object from objects[1]`) that occurred when loading a Native Ad in environments using `AppDelegate.swift` (e.g., Expo SDK 53 and above).

### Related issues

- #704 

### Release Summary

- Fixes crash by safely handling `nil` before returning data on iOS.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
