### PR TITLE
fix(native, ios): fixed null responseIdentifier crash

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
@@ -88,7 +88,7 @@ RCT_EXPORT_METHOD(
           reject(@"ERROR_LOAD", @"Failed to get a valid response ID from the loaded ad.", nil);
           return;
         }
-        
+
         [_adHolders setValue:adHolder forKey:responseId];
 
         resolve(@{


### PR DESCRIPTION
### Description

Fix: [iOS] Prevent potential nil-key crashes in Native Ad module
This PR hardens the Native Module against potential crashes caused by inserting `nil` values into an `NSMutableDictionary`.

- `load:` Method:
  - Added a nil check. If `responseId` is `nil`, we now reject the promise with an error instead of crashing the app when trying to set the value in `_adHolders`. Now matches [Android implementation](https://github.com/invertase/react-native-google-mobile-ads/blob/fc6d03b19967fb319da41b2103b1a72f97d87f87/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeModule.kt#L46).

- `destroy:` Method:
  - Added a nil check before calling `removeObjectForKey:` to prevent an `NSInvalidArgumentException`.

- `emitAdEvent:withData:` Method:
  - Updated to use `responseId ?: [NSNull null]` to match the safe handling already used for responseId in the code.
  - Made the ad event a `nonnull` parameter. 

### Release Summary

Resolving crash `NSInvalidArgumentException: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]`

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
