### PR TITLE
feat: new arch support for banner , full screen ads and mobilesdk module on android (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ When using The New Architecture, some legacy code will still be used though. See
 | Android  | Native Ads (Turbo Native Module, Fabric Native Component)                                                                                                      | ✅ Complete |
 | Android  | User Messaging Platform (Turbo Native Module)                                                                                                                  | ⏳ To-Do    |
 | Android  | [EventEmitter](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/turbo-modules.md#add-event-emitting-capabilities) (Turbo Native Module) | ⏳ To-Do    |
-| Android  | Revenue Precision Constants (Turbo Native Module)                                                                                                              | ⏳ To-Do    | 
+| Android  | Revenue Precision Constants (Turbo Native Module)                                                                                                              | ⏳ To-Do    |
 
 ## Documentation
 


### PR DESCRIPTION
### Description

This PR migrates key Android components to React Native’s New Architecture (TurboModules/Fabric) and updates documentation to reflect the current migration status.

- Implemented native specs and refactored modules for New Architecture compatibility.
- Confirmed Banner Ads are using a Fabric Native Component via codegen.
- Migrated Mobile Ads SDK methods and Full Screen Ad modules (App Open, Interstitial, Rewarded, Rewarded Interstitial) to the New Architecture. fv
- Updated the Android rows in the README’s “Migrating to the New Architecture Status” table.

### Related issues

- N/A

### Release Summary

Android migration to New Architecture for core ads modules; documentation updated to reflect current status.

### Checklist

- I read the Contributor Guide and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Verified that Android Banner component renders via Fabric using the codegen native component (`GoogleMobileAdsBannerViewNativeComponent`) and manager (`ReactNativeGoogleMobileAdsBannerAdViewManager`).
- Validated Full Screen Ads lifecycle under the new TurboModule implementations:
  - App Open, Interstitial, Rewarded, Rewarded Interstitial load/show/dismiss flows.
- Ensured README status accurately reflects current migration state.

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter