### PR TITLE
feat: new arch support for banner , full screen ads and mobilesdk module on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ When using The New Architecture, some legacy code will still be used though. See
 | iOS      | User Messaging Platform (Turbo Native Module)                                                                                                                  | ✅ Complete |
 | iOS      | [EventEmitter](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/turbo-modules.md#add-event-emitting-capabilities) (Turbo Native Module) | ⏳ To-Do    |
 | iOS      | Revenue Precision Constants (Turbo Native Module)                                                                                                              | ✅ Complete |
-| Android  | Mobile Ads SDK Methods (Turbo Native Module)                                                                                                                   | ⏳ To-Do    |
-| Android  | Banners (Fabric Native Component)                                                                                                                              | ⏳ To-Do    |
-| Android  | Full Screen Ads (Turbo Native Module)                                                                                                                          | ⏳ To-Do    |
+| Android  | Mobile Ads SDK Methods (Turbo Native Module)                                                                                                                   | ✅ Complete |
+| Android  | Banners (Fabric Native Component)                                                                                                                              | ✅ Complete |
+| Android  | Full Screen Ads (Turbo Native Module)                                                                                                                          | ✅ Complete |
 | Android  | Native Ads (Turbo Native Module, Fabric Native Component)                                                                                                      | ✅ Complete |
 | Android  | User Messaging Platform (Turbo Native Module)                                                                                                                  | ⏳ To-Do    |
 | Android  | [EventEmitter](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/turbo-modules.md#add-event-emitting-capabilities) (Turbo Native Module) | ⏳ To-Do    |

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeAppModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeAppModule.java
@@ -17,8 +17,11 @@ package io.invertase.googlemobileads;
  *
  */
 
+import androidx.annotation.NonNull;
+
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import io.invertase.googlemobileads.common.RCTConvert;
@@ -26,20 +29,27 @@ import io.invertase.googlemobileads.common.ReactNativeEvent;
 import io.invertase.googlemobileads.common.ReactNativeEventEmitter;
 import io.invertase.googlemobileads.common.ReactNativeJSON;
 import io.invertase.googlemobileads.common.ReactNativeMeta;
-import io.invertase.googlemobileads.common.ReactNativeModule;
 import io.invertase.googlemobileads.common.ReactNativePreferences;
 
-public class ReactNativeAppModule extends ReactNativeModule {
+public class ReactNativeAppModule extends ReactContextBaseJavaModule {
   static final String NAME = "RNAppModule";
+  ReactApplicationContext context;
 
   ReactNativeAppModule(ReactApplicationContext reactContext) {
-    super(reactContext, NAME);
+    super(reactContext);
+    context=reactContext;
+  }
+
+  @NonNull
+  @Override
+  public String getName() {
+    return NAME;
   }
 
   @Override
   public void initialize() {
     super.initialize();
-    ReactNativeEventEmitter.getSharedInstance().attachReactContext(getContext());
+    ReactNativeEventEmitter.getSharedInstance().attachReactContext(context);
   }
 
   @ReactMethod

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.kt
@@ -1,31 +1,34 @@
 package io.invertase.googlemobileads
 
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
-import com.google.android.gms.ads.appopen.AppOpenAd
 
 class ReactNativeGoogleMobileAdsAppOpenModule(reactContext: ReactApplicationContext?) :
   NativeAppOpenModuleSpec(reactContext) {
 
-    private var instance: ReactNativeGoogleMobileAdsAppOpenModuleImpl = ReactNativeGoogleMobileAdsAppOpenModuleImpl(reactContext)
+  private var instance: ReactNativeGoogleMobileAdsAppOpenModuleImpl =
+    ReactNativeGoogleMobileAdsAppOpenModuleImpl(reactContext)
+
   override fun appOpenLoad(
     requestId: Double,
-    adUnitId: String?,
+    adUnitId: String,
     requestOptions: ReadableMap?
   ) {
-//    instance.appOpenLoad()
+    instance.appOpenLoad(requestId.toInt(), adUnitId, requestOptions ?: Arguments.createMap())
   }
 
   override fun appOpenShow(
     requestId: Double,
-    adUnitId: String?,
+    adUnitId: String,
     showOptions: ReadableMap?,
-    promise: Promise?
+    promise: Promise
   ) {
-//    instance.appOpenShow()
+    instance.appOpenShow(requestId.toInt(), adUnitId, showOptions ?: Arguments.createMap(), promise)
   }
-  companion object{
-  const val NAME = NativeAppOpenModuleSpec.NAME
+
+  companion object {
+    const val NAME = NativeAppOpenModuleSpec.NAME
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModule.kt
@@ -1,73 +1,31 @@
 package io.invertase.googlemobileads
 
-/*
- * Copyright (c) 2016-present Invertase Limited & Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this library except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
-import android.app.Activity
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import com.google.android.gms.ads.AdLoadCallback
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import com.google.android.gms.ads.appopen.AppOpenAd
 
 class ReactNativeGoogleMobileAdsAppOpenModule(reactContext: ReactApplicationContext?) :
-  ReactNativeGoogleMobileAdsFullScreenAdModule<AppOpenAd>(reactContext, NAME) {
+  NativeAppOpenModuleSpec(reactContext) {
 
-  override fun getAdEventName(): String {
-    return ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_APP_OPEN
-  }
-
-  @ReactMethod
-  fun appOpenLoad(requestId: Int, adUnitId: String, adRequestOptions: ReadableMap) {
-    load(requestId, adUnitId, adRequestOptions)
-  }
-
-  @ReactMethod
-  fun appOpenShow(
-    requestId: Int, adUnitId: String, showOptions: ReadableMap, promise: Promise
+    private var instance: ReactNativeGoogleMobileAdsAppOpenModuleImpl = ReactNativeGoogleMobileAdsAppOpenModuleImpl(reactContext)
+  override fun appOpenLoad(
+    requestId: Double,
+    adUnitId: String?,
+    requestOptions: ReadableMap?
   ) {
-    show(requestId, adUnitId, showOptions, promise)
+//    instance.appOpenLoad()
   }
 
-  override fun loadAd(
-    activity: Activity,
-    adUnitId: String,
-    adRequest: AdManagerAdRequest,
-    adLoadCallback: AdLoadCallback<AppOpenAd>
+  override fun appOpenShow(
+    requestId: Double,
+    adUnitId: String?,
+    showOptions: ReadableMap?,
+    promise: Promise?
   ) {
-    AppOpenAd.load(
-      activity,
-      adUnitId,
-      adRequest,
-      object :
-        AppOpenAd.AppOpenAdLoadCallback() {
-        override fun onAdLoaded(ad: AppOpenAd) {
-          adLoadCallback.onAdLoaded(ad)
-        }
-        override fun onAdFailedToLoad(error: LoadAdError) {
-          adLoadCallback.onAdFailedToLoad(error)
-        }
-      })
+//    instance.appOpenShow()
   }
-
-  companion object {
-    const val NAME = "RNGoogleMobileAdsAppOpenModule"
+  companion object{
+  const val NAME = NativeAppOpenModuleSpec.NAME
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModuleImpl.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModuleImpl.kt
@@ -58,6 +58,7 @@ class ReactNativeGoogleMobileAdsAppOpenModuleImpl(reactContext: ReactApplication
         override fun onAdLoaded(ad: AppOpenAd) {
           adLoadCallback.onAdLoaded(ad)
         }
+
         override fun onAdFailedToLoad(error: LoadAdError) {
           adLoadCallback.onAdFailedToLoad(error)
         }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModuleImpl.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsAppOpenModuleImpl.kt
@@ -1,0 +1,66 @@
+package io.invertase.googlemobileads
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import android.app.Activity
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import com.google.android.gms.ads.AdLoadCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.admanager.AdManagerAdRequest
+import com.google.android.gms.ads.appopen.AppOpenAd
+
+class ReactNativeGoogleMobileAdsAppOpenModuleImpl(reactContext: ReactApplicationContext?) :
+  ReactNativeGoogleMobileAdsFullScreenAdModule<AppOpenAd>(reactContext) {
+
+  override fun getAdEventName(): String {
+    return ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_APP_OPEN
+  }
+
+  fun appOpenLoad(requestId: Int, adUnitId: String, adRequestOptions: ReadableMap) {
+    load(requestId, adUnitId, adRequestOptions)
+  }
+
+  fun appOpenShow(
+    requestId: Int, adUnitId: String, showOptions: ReadableMap, promise: Promise
+  ) {
+    show(requestId, adUnitId, showOptions, promise)
+  }
+
+  override fun loadAd(
+    activity: Activity,
+    adUnitId: String,
+    adRequest: AdManagerAdRequest,
+    adLoadCallback: AdLoadCallback<AppOpenAd>
+  ) {
+    AppOpenAd.load(
+      activity,
+      adUnitId,
+      adRequest,
+      object :
+        AppOpenAd.AppOpenAdLoadCallback() {
+        override fun onAdLoaded(ad: AppOpenAd) {
+          adLoadCallback.onAdLoaded(ad)
+        }
+        override fun onAdFailedToLoad(error: LoadAdError) {
+          adLoadCallback.onAdFailedToLoad(error)
+        }
+      })
+  }
+}

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsBannerAdViewManager.java
@@ -19,7 +19,9 @@ package io.invertase.googlemobileads;
 
 import android.app.Activity;
 import android.view.ViewGroup;
+
 import androidx.annotation.NonNull;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -46,18 +48,22 @@ import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.OnPaidEventListener;
 import com.google.android.gms.ads.admanager.AdManagerAdView;
 import com.google.android.gms.ads.admanager.AppEventListener;
+
 import io.invertase.googlemobileads.common.ReactNativeAdView;
 import io.invertase.googlemobileads.common.SharedUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class ReactNativeGoogleMobileAdsBannerAdViewManager
-    extends SimpleViewManager<ReactNativeAdView> implements RNGoogleMobileAdsBannerViewManagerInterface<ReactNativeAdView> {
+  extends SimpleViewManager<ReactNativeAdView> implements RNGoogleMobileAdsBannerViewManagerInterface<ReactNativeAdView> {
   private static final String REACT_CLASS = "RNGoogleMobileAdsBannerView";
   private final String EVENT_AD_LOADED = "onAdLoaded";
   private final String EVENT_AD_IMPRESSION = "onAdImpression";
@@ -68,7 +74,8 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
   private final String EVENT_PAID = "onPaid";
   private final String EVENT_SIZE_CHANGE = "onSizeChange";
   private final String EVENT_APP_EVENT = "onAppEvent";
-  private final ViewManagerDelegate<ReactNativeAdView> delegate  = new RNGoogleMobileAdsBannerViewManagerDelegate<>(this);
+  private final ViewManagerDelegate<ReactNativeAdView> delegate = new RNGoogleMobileAdsBannerViewManagerDelegate<>(this);
+
   @Nonnull
   @Override
   public String getName() {
@@ -140,7 +147,7 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
             if (sizesArray.getType(i) == ReadableType.String) {
               String sizeString = sizesArray.getString(i);
               AdSize adSize =
-                  ReactNativeGoogleMobileAdsCommon.getAdSize(sizeString, reactViewGroup);
+                ReactNativeGoogleMobileAdsCommon.getAdSize(sizeString, reactViewGroup);
               sizeList.add(adSize);
             }
           }
@@ -180,7 +187,7 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
   public void load(ReactNativeAdView view) {
     BaseAdView adView = getAdView(view);
     AdRequest request = view.getRequest();
-    if(adView !=null) {
+    if (adView != null) {
       adView.loadAd(request);
     }
   }
@@ -226,95 +233,95 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
     if (currentActivity == null) return null;
 
     BaseAdView adView =
-        ReactNativeGoogleMobileAdsCommon.isAdManagerUnit(reactViewGroup.getUnitId())
-            ? new AdManagerAdView(currentActivity)
-            : new AdView(currentActivity);
+      ReactNativeGoogleMobileAdsCommon.isAdManagerUnit(reactViewGroup.getUnitId())
+        ? new AdManagerAdView(currentActivity)
+        : new AdView(currentActivity);
 
     adView.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);
     adView.setOnPaidEventListener(
-        new OnPaidEventListener() {
-          @Override
-          public void onPaidEvent(AdValue adValue) {
-            WritableMap payload = Arguments.createMap();
-            payload.putDouble("value", 1e-6 * adValue.getValueMicros());
-            payload.putDouble("precision", adValue.getPrecisionType());
-            payload.putString("currency", adValue.getCurrencyCode());
-            sendEvent(reactViewGroup, EVENT_PAID, payload);
-          }
-        });
+      new OnPaidEventListener() {
+        @Override
+        public void onPaidEvent(AdValue adValue) {
+          WritableMap payload = Arguments.createMap();
+          payload.putDouble("value", 1e-6 * adValue.getValueMicros());
+          payload.putDouble("precision", adValue.getPrecisionType());
+          payload.putString("currency", adValue.getCurrencyCode());
+          sendEvent(reactViewGroup, EVENT_PAID, payload);
+        }
+      });
     adView.setAdListener(
-        new AdListener() {
-          @Override
-          public void onAdLoaded() {
-            AdSize adSize = adView.getAdSize();
-            int width, height;
-            if (reactViewGroup.getIsFluid()) {
-              width = reactViewGroup.getWidth();
-              height = reactViewGroup.getHeight();
+      new AdListener() {
+        @Override
+        public void onAdLoaded() {
+          AdSize adSize = adView.getAdSize();
+          int width, height;
+          if (reactViewGroup.getIsFluid()) {
+            width = reactViewGroup.getWidth();
+            height = reactViewGroup.getHeight();
 
-              adView.addOnLayoutChangeListener(
-                  (v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
-                    WritableMap payload = Arguments.createMap();
-                    payload.putDouble("width", PixelUtil.toDIPFromPixel(right - left));
-                    payload.putDouble("height", PixelUtil.toDIPFromPixel(bottom - top));
-                    sendEvent(reactViewGroup, EVENT_SIZE_CHANGE, payload);
-                  });
-            } else {
-              int left = adView.getLeft();
-              int top = adView.getTop();
-              width = adSize.getWidthInPixels(reactViewGroup.getContext());
-              height = adSize.getHeightInPixels(reactViewGroup.getContext());
+            adView.addOnLayoutChangeListener(
+              (v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
+                WritableMap payload = Arguments.createMap();
+                payload.putDouble("width", PixelUtil.toDIPFromPixel(right - left));
+                payload.putDouble("height", PixelUtil.toDIPFromPixel(bottom - top));
+                sendEvent(reactViewGroup, EVENT_SIZE_CHANGE, payload);
+              });
+          } else {
+            int left = adView.getLeft();
+            int top = adView.getTop();
+            width = adSize.getWidthInPixels(reactViewGroup.getContext());
+            height = adSize.getHeightInPixels(reactViewGroup.getContext());
 
-              adView.measure(width, height);
-              adView.layout(left, top, left + width, top + height);
-            }
-
-            WritableMap payload = Arguments.createMap();
-            payload.putDouble("width", PixelUtil.toDIPFromPixel(width));
-            payload.putDouble("height", PixelUtil.toDIPFromPixel(height));
-
-            sendEvent(reactViewGroup, EVENT_AD_LOADED, payload);
+            adView.measure(width, height);
+            adView.layout(left, top, left + width, top + height);
           }
 
-          @Override
-          public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
-            int errorCode = loadAdError.getCode();
-            WritableMap payload = ReactNativeGoogleMobileAdsCommon.errorCodeToMap(errorCode);
-            sendEvent(reactViewGroup, EVENT_AD_FAILED_TO_LOAD, payload);
-          }
+          WritableMap payload = Arguments.createMap();
+          payload.putDouble("width", PixelUtil.toDIPFromPixel(width));
+          payload.putDouble("height", PixelUtil.toDIPFromPixel(height));
 
-          @Override
-          public void onAdOpened() {
-            sendEvent(reactViewGroup, EVENT_AD_OPENED, null);
-          }
+          sendEvent(reactViewGroup, EVENT_AD_LOADED, payload);
+        }
 
-          @Override
-          public void onAdClosed() {
-            sendEvent(reactViewGroup, EVENT_AD_CLOSED, null);
-          }
+        @Override
+        public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
+          int errorCode = loadAdError.getCode();
+          WritableMap payload = ReactNativeGoogleMobileAdsCommon.errorCodeToMap(errorCode);
+          sendEvent(reactViewGroup, EVENT_AD_FAILED_TO_LOAD, payload);
+        }
 
-          @Override
-          public void onAdImpression() {
-            sendEvent(reactViewGroup, EVENT_AD_IMPRESSION, null);
-          }
+        @Override
+        public void onAdOpened() {
+          sendEvent(reactViewGroup, EVENT_AD_OPENED, null);
+        }
 
-          @Override
-          public void onAdClicked() {
-            sendEvent(reactViewGroup, EVENT_AD_CLICKED, null);
-          }
-        });
+        @Override
+        public void onAdClosed() {
+          sendEvent(reactViewGroup, EVENT_AD_CLOSED, null);
+        }
+
+        @Override
+        public void onAdImpression() {
+          sendEvent(reactViewGroup, EVENT_AD_IMPRESSION, null);
+        }
+
+        @Override
+        public void onAdClicked() {
+          sendEvent(reactViewGroup, EVENT_AD_CLICKED, null);
+        }
+      });
     if (adView instanceof AdManagerAdView) {
       ((AdManagerAdView) adView)
-          .setAppEventListener(
-              new AppEventListener() {
-                @Override
-                public void onAppEvent(@NonNull String name, @Nullable String data) {
-                  WritableMap payload = Arguments.createMap();
-                  payload.putString("name", name);
-                  payload.putString("data", data);
-                  sendEvent(reactViewGroup, EVENT_APP_EVENT, payload);
-                }
-              });
+        .setAppEventListener(
+          new AppEventListener() {
+            @Override
+            public void onAppEvent(@NonNull String name, @Nullable String data) {
+              WritableMap payload = Arguments.createMap();
+              payload.putString("name", name);
+              payload.putString("data", data);
+              sendEvent(reactViewGroup, EVENT_APP_EVENT, payload);
+            }
+          });
     }
     reactViewGroup.addView(adView);
     return adView;
@@ -366,7 +373,7 @@ public class ReactNativeGoogleMobileAdsBannerAdViewManager
 
     ThemedReactContext themedReactContext = ((ThemedReactContext) reactViewGroup.getContext());
     EventDispatcher eventDispatcher =
-        UIManagerHelper.getEventDispatcherForReactTag(themedReactContext, reactViewGroup.getId());
+      UIManagerHelper.getEventDispatcherForReactTag(themedReactContext, reactViewGroup.getId());
     if (eventDispatcher != null) {
       eventDispatcher.dispatchEvent(new OnNativeEvent(reactViewGroup.getId(), event));
     }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
@@ -16,9 +16,11 @@ package io.invertase.googlemobileads;
  * limitations under the License.
  *
  */
+
 import android.app.Activity;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -30,6 +32,7 @@ import com.google.android.ump.ConsentDebugSettings;
 import com.google.android.ump.ConsentInformation;
 import com.google.android.ump.ConsentRequestParameters;
 import com.google.android.ump.UserMessagingPlatform;
+
 import javax.annotation.Nonnull;
 
 public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModuleSpec {
@@ -57,7 +60,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
   }
 
   private String getPrivacyOptionsRequirementStatusString(
-      ConsentInformation.PrivacyOptionsRequirementStatus privacyOptionsRequirementStatus) {
+    ConsentInformation.PrivacyOptionsRequirementStatus privacyOptionsRequirementStatus) {
     switch (privacyOptionsRequirementStatus) {
       case REQUIRED:
         return "REQUIRED";
@@ -72,14 +75,14 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
   private WritableMap getConsentInformation() {
     WritableMap consentStatusMap = Arguments.createMap();
     consentStatusMap.putString(
-        "status", getConsentStatusString(consentInformation.getConsentStatus()));
+      "status", getConsentStatusString(consentInformation.getConsentStatus()));
     consentStatusMap.putBoolean("canRequestAds", consentInformation.canRequestAds());
     consentStatusMap.putString(
-        "privacyOptionsRequirementStatus",
-        getPrivacyOptionsRequirementStatusString(
-            consentInformation.getPrivacyOptionsRequirementStatus()));
+      "privacyOptionsRequirementStatus",
+      getPrivacyOptionsRequirementStatusString(
+        consentInformation.getPrivacyOptionsRequirementStatus()));
     consentStatusMap.putBoolean(
-        "isConsentFormAvailable", consentInformation.isConsentFormAvailable());
+      "isConsentFormAvailable", consentInformation.isConsentFormAvailable());
     return consentStatusMap;
   }
 
@@ -88,7 +91,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
     try {
       ConsentRequestParameters.Builder paramsBuilder = new ConsentRequestParameters.Builder();
       ConsentDebugSettings.Builder debugSettingsBuilder =
-          new ConsentDebugSettings.Builder(context.getApplicationContext());
+        new ConsentDebugSettings.Builder(context.getApplicationContext());
 
       if (options.hasKey("testDeviceIdentifiers")) {
         ReadableArray devices = options.getArray("testDeviceIdentifiers");
@@ -114,21 +117,21 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
 
       if (currentActivity == null) {
         rejectPromiseWithCodeAndMessage(
-            promise,
-            "null-activity",
-            "Attempted to request a consent info update but the current Activity was null.");
+          promise,
+          "null-activity",
+          "Attempted to request a consent info update but the current Activity was null.");
         return;
       }
 
       consentInformation.requestConsentInfoUpdate(
-          currentActivity,
-          consentRequestParameters,
-          () -> {
-            promise.resolve(getConsentInformation());
-          },
-          formError ->
-              rejectPromiseWithCodeAndMessage(
-                  promise, "consent-update-failed", formError.getMessage()));
+        currentActivity,
+        consentRequestParameters,
+        () -> {
+          promise.resolve(getConsentInformation());
+        },
+        formError ->
+          rejectPromiseWithCodeAndMessage(
+            promise, "consent-update-failed", formError.getMessage()));
     } catch (Exception e) {
       rejectPromiseWithCodeAndMessage(promise, "consent-update-failed", e.toString());
     }
@@ -141,30 +144,30 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
 
       if (currentActivity == null) {
         rejectPromiseWithCodeAndMessage(
-            promise,
-            "null-activity",
-            "Consent form attempted to show but the current Activity was null.");
+          promise,
+          "null-activity",
+          "Consent form attempted to show but the current Activity was null.");
         return;
       }
 
       currentActivity.runOnUiThread(
-          () ->
-              UserMessagingPlatform.loadConsentForm(
-                  getReactApplicationContext(),
-                  consentForm ->
-                      consentForm.show(
-                          currentActivity,
-                          formError -> {
-                            if (formError != null) {
-                              rejectPromiseWithCodeAndMessage(
-                                  promise, "consent-form-error", formError.getMessage());
-                            } else {
-                              promise.resolve(getConsentInformation());
-                            }
-                          }),
-                  formError ->
-                      rejectPromiseWithCodeAndMessage(
-                          promise, "consent-form-error", formError.getMessage())));
+        () ->
+          UserMessagingPlatform.loadConsentForm(
+            getReactApplicationContext(),
+            consentForm ->
+              consentForm.show(
+                currentActivity,
+                formError -> {
+                  if (formError != null) {
+                    rejectPromiseWithCodeAndMessage(
+                      promise, "consent-form-error", formError.getMessage());
+                  } else {
+                    promise.resolve(getConsentInformation());
+                  }
+                }),
+            formError ->
+              rejectPromiseWithCodeAndMessage(
+                promise, "consent-form-error", formError.getMessage())));
     } catch (Exception e) {
       rejectPromiseWithCodeAndMessage(promise, "consent-form-error", e.toString());
     }
@@ -177,24 +180,24 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
 
       if (currentActivity == null) {
         rejectPromiseWithCodeAndMessage(
-            promise,
-            "null-activity",
-            "Privacy options form attempted to show but the current Activity was null.");
+          promise,
+          "null-activity",
+          "Privacy options form attempted to show but the current Activity was null.");
         return;
       }
 
       currentActivity.runOnUiThread(
-          () ->
-              UserMessagingPlatform.showPrivacyOptionsForm(
-                  currentActivity,
-                  formError -> {
-                    if (formError != null) {
-                      rejectPromiseWithCodeAndMessage(
-                          promise, "privacy-options-form-error", formError.getMessage());
-                    } else {
-                      promise.resolve(getConsentInformation());
-                    }
-                  }));
+        () ->
+          UserMessagingPlatform.showPrivacyOptionsForm(
+            currentActivity,
+            formError -> {
+              if (formError != null) {
+                rejectPromiseWithCodeAndMessage(
+                  promise, "privacy-options-form-error", formError.getMessage());
+              } else {
+                promise.resolve(getConsentInformation());
+              }
+            }));
     } catch (Exception e) {
       rejectPromiseWithCodeAndMessage(promise, "consent-form-error", e.toString());
     }
@@ -207,25 +210,25 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
 
       if (currentActivity == null) {
         rejectPromiseWithCodeAndMessage(
-            promise,
-            "null-activity",
-            "Consent form attempted to load and show if required but the current Activity was"
-                + " null.");
+          promise,
+          "null-activity",
+          "Consent form attempted to load and show if required but the current Activity was"
+            + " null.");
         return;
       }
 
       currentActivity.runOnUiThread(
-          () ->
-              UserMessagingPlatform.loadAndShowConsentFormIfRequired(
-                  currentActivity,
-                  formError -> {
-                    if (formError != null) {
-                      rejectPromiseWithCodeAndMessage(
-                          promise, "consent-form-error", formError.getMessage());
-                    } else {
-                      promise.resolve(getConsentInformation());
-                    }
-                  }));
+        () ->
+          UserMessagingPlatform.loadAndShowConsentFormIfRequired(
+            currentActivity,
+            formError -> {
+              if (formError != null) {
+                rejectPromiseWithCodeAndMessage(
+                  promise, "consent-form-error", formError.getMessage());
+              } else {
+                promise.resolve(getConsentInformation());
+              }
+            }));
     } catch (Exception e) {
       rejectPromiseWithCodeAndMessage(promise, "consent-form-error", e.toString());
     }
@@ -245,7 +248,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
   public void getTCString(Promise promise) {
     try {
       SharedPreferences prefs =
-          PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
+        PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
       // https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#in-app-details
       String tcString = prefs.getString("IABTCF_TCString", null);
       promise.resolve(tcString);
@@ -258,7 +261,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
   public void getGdprApplies(Promise promise) {
     try {
       SharedPreferences prefs =
-          PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
+        PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
       int gdprApplies = prefs.getInt("IABTCF_gdprApplies", 0);
       promise.resolve(gdprApplies == 1);
     } catch (Exception e) {
@@ -270,7 +273,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
   public void getPurposeConsents(Promise promise) {
     try {
       SharedPreferences prefs =
-          PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
+        PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
       String purposeConsents = prefs.getString("IABTCF_PurposeConsents", "");
       promise.resolve(purposeConsents);
     } catch (Exception e) {
@@ -282,7 +285,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModule
   public void getPurposeLegitimateInterests(Promise promise) {
     try {
       SharedPreferences prefs =
-          PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
+        PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
       String purposeLegitimateInterests = prefs.getString("IABTCF_PurposeLegitimateInterests", "");
       promise.resolve(purposeLegitimateInterests);
     } catch (Exception e) {

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsConsentModule.java
@@ -30,16 +30,15 @@ import com.google.android.ump.ConsentDebugSettings;
 import com.google.android.ump.ConsentInformation;
 import com.google.android.ump.ConsentRequestParameters;
 import com.google.android.ump.UserMessagingPlatform;
-import io.invertase.googlemobileads.common.ReactNativeModule;
 import javax.annotation.Nonnull;
 
-public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
-
-  static final String NAME = "RNGoogleMobileAdsConsentModule";
+public class ReactNativeGoogleMobileAdsConsentModule extends NativeConsentModuleSpec {
   private ConsentInformation consentInformation;
+  private ReactApplicationContext context;
 
   public ReactNativeGoogleMobileAdsConsentModule(ReactApplicationContext reactContext) {
-    super(reactContext, NAME);
+    super(reactContext);
+    context = reactContext;
     consentInformation = UserMessagingPlatform.getConsentInformation(reactContext);
   }
 
@@ -89,7 +88,7 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
     try {
       ConsentRequestParameters.Builder paramsBuilder = new ConsentRequestParameters.Builder();
       ConsentDebugSettings.Builder debugSettingsBuilder =
-          new ConsentDebugSettings.Builder(getApplicationContext());
+          new ConsentDebugSettings.Builder(context.getApplicationContext());
 
       if (options.hasKey("testDeviceIdentifiers")) {
         ReadableArray devices = options.getArray("testDeviceIdentifiers");
@@ -289,5 +288,12 @@ public class ReactNativeGoogleMobileAdsConsentModule extends ReactNativeModule {
     } catch (Exception e) {
       rejectPromiseWithCodeAndMessage(promise, "consent-string-error", e.toString());
     }
+  }
+
+  public static void rejectPromiseWithCodeAndMessage(Promise promise, String code, String message) {
+    WritableMap userInfoMap = Arguments.createMap();
+    userInfoMap.putString("code", code);
+    userInfoMap.putString("message", message);
+    promise.reject(code, message, userInfoMap);
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsFullScreenAdModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsFullScreenAdModule.kt
@@ -250,8 +250,8 @@ abstract class ReactNativeGoogleMobileAdsFullScreenAdModule<T>(
           data
         )
       } catch (e: Exception) {
-          Log.w("RNGoogleMobileAds", "Unknown error on load")
-          Log.w("RNGoogleMobileAds", e)
+        Log.w("RNGoogleMobileAds", "Unknown error on load")
+        Log.w("RNGoogleMobileAds", e)
         val error = Arguments.createMap()
         error.putString("code", "internal")
         error.putString("message", e.message)

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsFullScreenAdModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsFullScreenAdModule.kt
@@ -36,8 +36,7 @@ import io.invertase.googlemobileads.common.ReactNativeModule
 
 abstract class ReactNativeGoogleMobileAdsFullScreenAdModule<T>(
   reactContext: ReactApplicationContext?,
-  moduleName: String
-) : ReactNativeModule(reactContext, moduleName) {
+) : ReactNativeModule(reactContext) {
   private val adArray = SparseArray<T>()
 
   abstract fun getAdEventName(): String
@@ -69,7 +68,7 @@ abstract class ReactNativeGoogleMobileAdsFullScreenAdModule<T>(
   fun load(
     requestId: Int, adUnitId: String, adRequestOptions: ReadableMap
   ) {
-    val activity = currentActivity
+    val activity = activity
     if (activity == null) {
       val error = Arguments.createMap()
       error.putString("code", "null-activity")
@@ -105,7 +104,7 @@ abstract class ReactNativeGoogleMobileAdsFullScreenAdModule<T>(
   fun show(
     requestId: Int, adUnitId: String, showOptions: ReadableMap, promise: Promise
   ) {
-    val activity = currentActivity
+    val activity = activity
     if (activity == null) {
       rejectPromiseWithCodeAndMessage(
         promise,

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.kt
@@ -1,74 +1,31 @@
 package io.invertase.googlemobileads
 
-/*
- * Copyright (c) 2016-present Invertase Limited & Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this library except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
-import android.app.Activity
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import com.google.android.gms.ads.AdLoadCallback
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAd
-import com.google.android.gms.ads.admanager.AdManagerInterstitialAdLoadCallback
 
 class ReactNativeGoogleMobileAdsInterstitialModule(reactContext: ReactApplicationContext?) :
-  ReactNativeGoogleMobileAdsFullScreenAdModule<AdManagerInterstitialAd>(reactContext, NAME) {
+  NativeInterstitialModuleSpec(reactContext) {
 
-  override fun getAdEventName(): String {
-    return ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_INTERSTITIAL
-  }
-
-  @ReactMethod
-  fun interstitialLoad(requestId: Int, adUnitId: String, adRequestOptions: ReadableMap) {
-    load(requestId, adUnitId, adRequestOptions)
-  }
-
-  @ReactMethod
-  fun interstitialShow(
-    requestId: Int, adUnitId: String, showOptions: ReadableMap, promise: Promise
+  private val instance: ReactNativeGoogleMobileAdsInterstitialModuleImpl = ReactNativeGoogleMobileAdsInterstitialModuleImpl(reactContext)
+  override fun interstitialLoad(
+    requestId: Double,
+    adUnitId: String?,
+    requestOptions: ReadableMap?
   ) {
-    show(requestId, adUnitId, showOptions, promise)
+//    instance.interstitialLoad()
   }
 
-  override fun loadAd(
-    activity: Activity,
-    adUnitId: String,
-    adRequest: AdManagerAdRequest,
-    adLoadCallback: AdLoadCallback<AdManagerInterstitialAd>
+  override fun interstitialShow(
+    requestId: Double,
+    adUnitId: String?,
+    showOptions: ReadableMap?,
+    promise: Promise?
   ) {
-    AdManagerInterstitialAd.load(
-      activity,
-      adUnitId,
-      adRequest,
-      object :
-        AdManagerInterstitialAdLoadCallback() {
-        override fun onAdLoaded(ad: AdManagerInterstitialAd) {
-          adLoadCallback.onAdLoaded(ad)
-        }
-        override fun onAdFailedToLoad(error: LoadAdError) {
-          adLoadCallback.onAdFailedToLoad(error)
-        }
-      })
+//    instance.interstitialShow()
   }
-
   companion object {
-    const val NAME = "RNGoogleMobileAdsInterstitialModule"
+    const val NAME = NativeInterstitialModuleSpec.NAME
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.kt
@@ -1,5 +1,6 @@
 package io.invertase.googlemobileads
 
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
@@ -11,19 +12,19 @@ class ReactNativeGoogleMobileAdsInterstitialModule(reactContext: ReactApplicatio
   private val instance: ReactNativeGoogleMobileAdsInterstitialModuleImpl = ReactNativeGoogleMobileAdsInterstitialModuleImpl(reactContext)
   override fun interstitialLoad(
     requestId: Double,
-    adUnitId: String?,
+    adUnitId: String,
     requestOptions: ReadableMap?
   ) {
-//    instance.interstitialLoad()
+    instance.interstitialLoad(requestId.toInt(), adUnitId, requestOptions?: Arguments.createMap())
   }
 
   override fun interstitialShow(
     requestId: Double,
-    adUnitId: String?,
+    adUnitId: String,
     showOptions: ReadableMap?,
-    promise: Promise?
+    promise: Promise
   ) {
-//    instance.interstitialShow()
+    instance.interstitialShow(requestId.toInt(), adUnitId, showOptions?: Arguments.createMap(),promise)
   }
   companion object {
     const val NAME = NativeInterstitialModuleSpec.NAME

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModule.kt
@@ -9,13 +9,15 @@ import com.google.android.gms.ads.admanager.AdManagerInterstitialAd
 class ReactNativeGoogleMobileAdsInterstitialModule(reactContext: ReactApplicationContext?) :
   NativeInterstitialModuleSpec(reactContext) {
 
-  private val instance: ReactNativeGoogleMobileAdsInterstitialModuleImpl = ReactNativeGoogleMobileAdsInterstitialModuleImpl(reactContext)
+  private val instance: ReactNativeGoogleMobileAdsInterstitialModuleImpl =
+    ReactNativeGoogleMobileAdsInterstitialModuleImpl(reactContext)
+
   override fun interstitialLoad(
     requestId: Double,
     adUnitId: String,
     requestOptions: ReadableMap?
   ) {
-    instance.interstitialLoad(requestId.toInt(), adUnitId, requestOptions?: Arguments.createMap())
+    instance.interstitialLoad(requestId.toInt(), adUnitId, requestOptions ?: Arguments.createMap())
   }
 
   override fun interstitialShow(
@@ -24,8 +26,14 @@ class ReactNativeGoogleMobileAdsInterstitialModule(reactContext: ReactApplicatio
     showOptions: ReadableMap?,
     promise: Promise
   ) {
-    instance.interstitialShow(requestId.toInt(), adUnitId, showOptions?: Arguments.createMap(),promise)
+    instance.interstitialShow(
+      requestId.toInt(),
+      adUnitId,
+      showOptions ?: Arguments.createMap(),
+      promise
+    )
   }
+
   companion object {
     const val NAME = NativeInterstitialModuleSpec.NAME
   }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModuleImpl.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsInterstitialModuleImpl.kt
@@ -1,0 +1,67 @@
+package io.invertase.googlemobileads
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import android.app.Activity
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import com.google.android.gms.ads.AdLoadCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.admanager.AdManagerAdRequest
+import com.google.android.gms.ads.admanager.AdManagerInterstitialAd
+import com.google.android.gms.ads.admanager.AdManagerInterstitialAdLoadCallback
+
+class ReactNativeGoogleMobileAdsInterstitialModuleImpl(reactContext: ReactApplicationContext?) :
+  ReactNativeGoogleMobileAdsFullScreenAdModule<AdManagerInterstitialAd>(reactContext) {
+
+  override fun getAdEventName(): String {
+    return ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_INTERSTITIAL
+  }
+
+  fun interstitialLoad(requestId: Int, adUnitId: String, adRequestOptions: ReadableMap) {
+    load(requestId, adUnitId, adRequestOptions)
+  }
+
+  fun interstitialShow(
+    requestId: Int, adUnitId: String, showOptions: ReadableMap, promise: Promise
+  ) {
+    show(requestId, adUnitId, showOptions, promise)
+  }
+
+  override fun loadAd(
+    activity: Activity,
+    adUnitId: String,
+    adRequest: AdManagerAdRequest,
+    adLoadCallback: AdLoadCallback<AdManagerInterstitialAd>
+  ) {
+    AdManagerInterstitialAd.load(
+      activity,
+      adUnitId,
+      adRequest,
+      object :
+        AdManagerInterstitialAdLoadCallback() {
+        override fun onAdLoaded(ad: AdManagerInterstitialAd) {
+          adLoadCallback.onAdLoaded(ad)
+        }
+        override fun onAdFailedToLoad(error: LoadAdError) {
+          adLoadCallback.onAdFailedToLoad(error)
+        }
+      })
+  }
+}

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.kt
@@ -38,7 +38,8 @@ class ReactNativeGoogleMobileAdsModule(
     val builder = RequestConfiguration.Builder()
 
     if (requestConfiguration.hasKey("testDeviceIdentifiers")) {
-      val devices = checkNotNull(requestConfiguration.getArray("testDeviceIdentifiers")).toArrayList()
+      val devices =
+        checkNotNull(requestConfiguration.getArray("testDeviceIdentifiers")).toArrayList()
       val testDeviceIds = devices.map {
         val id = it as String;
         if (id == "EMULATOR") {
@@ -63,7 +64,8 @@ class ReactNativeGoogleMobileAdsModule(
     }
 
     if (requestConfiguration.hasKey("tagForChildDirectedTreatment")) {
-      val tagForChildDirectedTreatment = requestConfiguration.getBoolean("tagForChildDirectedTreatment")
+      val tagForChildDirectedTreatment =
+        requestConfiguration.getBoolean("tagForChildDirectedTreatment")
       builder.setTagForChildDirectedTreatment(
         if (tagForChildDirectedTreatment) {
           RequestConfiguration.TAG_FOR_CHILD_DIRECTED_TREATMENT_TRUE
@@ -116,14 +118,21 @@ class ReactNativeGoogleMobileAdsModule(
     requestConfiguration: ReadableMap?,
     promise: Promise
   ) {
-    MobileAds.setRequestConfiguration(buildRequestConfiguration(requestConfiguration?: Arguments.createMap()))
+    MobileAds.setRequestConfiguration(
+      buildRequestConfiguration(
+        requestConfiguration ?: Arguments.createMap()
+      )
+    )
     promise.resolve(null)
   }
 
   override fun openAdInspector(promise: Promise) {
     val activity = reactApplicationContext.currentActivity
     if (activity == null) {
-      promise.reject("null-activity", "Ad Inspector attempted to open but the current Activity was null.")
+      promise.reject(
+        "null-activity",
+        "Ad Inspector attempted to open but the current Activity was null."
+      )
       return
     }
     activity.runOnUiThread {

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsModule.kt
@@ -28,7 +28,7 @@ import com.google.android.gms.ads.OnAdInspectorClosedListener
 
 class ReactNativeGoogleMobileAdsModule(
   reactContext: ReactApplicationContext
-) : ReactContextBaseJavaModule(reactContext) {
+) : NativeGoogleMobileAdsModuleSpec(reactContext) {
 
   override fun getName() = NAME
 
@@ -91,8 +91,7 @@ class ReactNativeGoogleMobileAdsModule(
     return builder.build()
   }
 
-  @ReactMethod
-  fun initialize(promise: Promise) {
+  override fun initialize(promise: Promise) {
     MobileAds.initialize(
       // in react-native, the Activity instance *may* go away, becoming null after initialize
       // it is not clear if that can happen here without an initialize necessarily following the Activity lifecycle
@@ -113,17 +112,15 @@ class ReactNativeGoogleMobileAdsModule(
       });
   }
 
-  @ReactMethod
-  fun setRequestConfiguration(
-    requestConfiguration: ReadableMap,
+  override fun setRequestConfiguration(
+    requestConfiguration: ReadableMap?,
     promise: Promise
   ) {
-    MobileAds.setRequestConfiguration(buildRequestConfiguration(requestConfiguration))
+    MobileAds.setRequestConfiguration(buildRequestConfiguration(requestConfiguration?: Arguments.createMap()))
     promise.resolve(null)
   }
 
-  @ReactMethod
-  fun openAdInspector(promise: Promise) {
+  override fun openAdInspector(promise: Promise) {
     val activity = reactApplicationContext.currentActivity
     if (activity == null) {
       promise.reject("null-activity", "Ad Inspector attempted to open but the current Activity was null.")
@@ -150,24 +147,21 @@ class ReactNativeGoogleMobileAdsModule(
     }
   }
 
-  @ReactMethod
-  fun openDebugMenu(adUnit: String) {
+  override fun openDebugMenu(adUnit: String) {
     reactApplicationContext.currentActivity?.runOnUiThread {
       MobileAds.openDebugMenu(reactApplicationContext.currentActivity!!, adUnit)
     }
   }
 
-  @ReactMethod
-  fun setAppVolume(volume: Float) {
-    MobileAds.setAppVolume(volume)
+  override fun setAppVolume(volume: Double) {
+    MobileAds.setAppVolume(volume.toFloat())
   }
 
-  @ReactMethod
-  fun setAppMuted(muted: Boolean) {
+  override fun setAppMuted(muted: Boolean) {
     MobileAds.setAppMuted(muted)
   }
 
   companion object {
-    const val NAME = "RNGoogleMobileAdsModule"
+    const val NAME = NativeGoogleMobileAdsModuleSpec.NAME
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeModule.kt
@@ -97,7 +97,10 @@ class ReactNativeGoogleMobileAdsNativeModule(
     return adHolders[responseId]?.nativeAd
   }
 
-  private inner class NativeAdHolder(private val adUnitId: String, private val requestOptions: ReadableMap) {
+  private inner class NativeAdHolder(
+    private val adUnitId: String,
+    private val requestOptions: ReadableMap
+  ) {
     var nativeAd: NativeAd? = null
       private set
 
@@ -119,27 +122,30 @@ class ReactNativeGoogleMobileAdsNativeModule(
       }
     }
 
-    private val videoLifecycleCallbacks: VideoLifecycleCallbacks = object : VideoLifecycleCallbacks() {
-      override fun onVideoPlay() {
-        emitAdEvent("video_played")
-      }
+    private val videoLifecycleCallbacks: VideoLifecycleCallbacks =
+      object : VideoLifecycleCallbacks() {
+        override fun onVideoPlay() {
+          emitAdEvent("video_played")
+        }
 
-      override fun onVideoPause() {
-        emitAdEvent("video_paused")
-      }
+        override fun onVideoPause() {
+          emitAdEvent("video_paused")
+        }
 
-      override fun onVideoEnd() {
-        emitAdEvent("video_ended")
-      }
+        override fun onVideoEnd() {
+          emitAdEvent("video_ended")
+        }
 
-      override fun onVideoMute(isMuted: Boolean) {
-        emitAdEvent(if (isMuted) {
-          "video_muted"
-        } else {
-          "video_unmuted"
-        })
+        override fun onVideoMute(isMuted: Boolean) {
+          emitAdEvent(
+            if (isMuted) {
+              "video_muted"
+            } else {
+              "video_unmuted"
+            }
+          )
+        }
       }
-    }
 
     fun loadAd(loadedListener: NativeAd.OnNativeAdLoadedListener) {
       val mediaAspectRatio = if (requestOptions.hasKey("aspectRatio")) {

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeModule.kt
@@ -216,6 +216,6 @@ class ReactNativeGoogleMobileAdsNativeModule(
   }
 
   companion object {
-    const val NAME = "RNGoogleMobileAdsNativeModule"
+    const val NAME = NativeGoogleMobileAdsNativeModuleSpec.NAME
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModule.kt
@@ -9,13 +9,19 @@ import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
 class ReactNativeGoogleMobileAdsRewardedInterstitialModule(reactContext: ReactApplicationContext?) :
   NativeRewardedInterstitialModuleSpec(reactContext) {
 
-  private val instance: ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl = ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl(reactContext)
+  private val instance: ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl =
+    ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl(reactContext)
+
   override fun rewardedInterstitialLoad(
     requestId: Double,
     adUnitId: String,
     requestOptions: ReadableMap?
   ) {
-    instance.rewardedInterstitialLoad(requestId.toInt(),adUnitId,requestOptions?: Arguments.createMap())
+    instance.rewardedInterstitialLoad(
+      requestId.toInt(),
+      adUnitId,
+      requestOptions ?: Arguments.createMap()
+    )
   }
 
   override fun rewardedInterstitialShow(
@@ -24,8 +30,14 @@ class ReactNativeGoogleMobileAdsRewardedInterstitialModule(reactContext: ReactAp
     showOptions: ReadableMap?,
     promise: Promise
   ) {
-    instance.rewardedInterstitialShow(requestId.toInt(), adUnitId, showOptions?:Arguments.createMap(),promise)
+    instance.rewardedInterstitialShow(
+      requestId.toInt(),
+      adUnitId,
+      showOptions ?: Arguments.createMap(),
+      promise
+    )
   }
+
   companion object {
     const val NAME = NativeRewardedInterstitialModuleSpec.NAME
   }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModule.kt
@@ -1,5 +1,6 @@
 package io.invertase.googlemobileads
 
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
@@ -11,19 +12,19 @@ class ReactNativeGoogleMobileAdsRewardedInterstitialModule(reactContext: ReactAp
   private val instance: ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl = ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl(reactContext)
   override fun rewardedInterstitialLoad(
     requestId: Double,
-    adUnitId: String?,
+    adUnitId: String,
     requestOptions: ReadableMap?
   ) {
-//    instance.rewardedInterstitialLoad()
+    instance.rewardedInterstitialLoad(requestId.toInt(),adUnitId,requestOptions?: Arguments.createMap())
   }
 
   override fun rewardedInterstitialShow(
     requestId: Double,
-    adUnitId: String?,
+    adUnitId: String,
     showOptions: ReadableMap?,
-    promise: Promise?
+    promise: Promise
   ) {
-//    instance.rewardedInterstitialShow()
+    instance.rewardedInterstitialShow(requestId.toInt(), adUnitId, showOptions?:Arguments.createMap(),promise)
   }
   companion object {
     const val NAME = NativeRewardedInterstitialModuleSpec.NAME

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModule.kt
@@ -1,74 +1,31 @@
 package io.invertase.googlemobileads
 
-/*
- * Copyright (c) 2016-present Invertase Limited & Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this library except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
-import android.app.Activity
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import com.google.android.gms.ads.AdLoadCallback
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
-import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAdLoadCallback
 
 class ReactNativeGoogleMobileAdsRewardedInterstitialModule(reactContext: ReactApplicationContext?) :
-  ReactNativeGoogleMobileAdsFullScreenAdModule<RewardedInterstitialAd>(reactContext, NAME) {
+  NativeRewardedInterstitialModuleSpec(reactContext) {
 
-  override fun getAdEventName(): String {
-    return ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_REWARDED_INTERSTITIAL
-  }
-
-  @ReactMethod
-  fun rewardedInterstitialLoad(requestId: Int, adUnitId: String, adRequestOptions: ReadableMap) {
-    load(requestId, adUnitId, adRequestOptions)
-  }
-
-  @ReactMethod
-  fun rewardedInterstitialShow(
-    requestId: Int, adUnitId: String, showOptions: ReadableMap, promise: Promise
+  private val instance: ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl = ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl(reactContext)
+  override fun rewardedInterstitialLoad(
+    requestId: Double,
+    adUnitId: String?,
+    requestOptions: ReadableMap?
   ) {
-    show(requestId, adUnitId, showOptions, promise)
+//    instance.rewardedInterstitialLoad()
   }
 
-  override fun loadAd(
-    activity: Activity,
-    adUnitId: String,
-    adRequest: AdManagerAdRequest,
-    adLoadCallback: AdLoadCallback<RewardedInterstitialAd>
+  override fun rewardedInterstitialShow(
+    requestId: Double,
+    adUnitId: String?,
+    showOptions: ReadableMap?,
+    promise: Promise?
   ) {
-    RewardedInterstitialAd.load(
-      activity,
-      adUnitId,
-      adRequest,
-      object :
-        RewardedInterstitialAdLoadCallback() {
-        override fun onAdLoaded(ad: RewardedInterstitialAd) {
-          adLoadCallback.onAdLoaded(ad)
-        }
-        override fun onAdFailedToLoad(error: LoadAdError) {
-          adLoadCallback.onAdFailedToLoad(error)
-        }
-      })
+//    instance.rewardedInterstitialShow()
   }
-
   companion object {
-    const val NAME = "RNGoogleMobileAdsRewardedInterstitialModule"
+    const val NAME = NativeRewardedInterstitialModuleSpec.NAME
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl.kt
@@ -59,6 +59,7 @@ class ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl(reactContext: Rea
         override fun onAdLoaded(ad: RewardedInterstitialAd) {
           adLoadCallback.onAdLoaded(ad)
         }
+
         override fun onAdFailedToLoad(error: LoadAdError) {
           adLoadCallback.onAdFailedToLoad(error)
         }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl.kt
@@ -1,0 +1,68 @@
+package io.invertase.googlemobileads
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import android.app.Activity
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import com.google.android.gms.ads.AdLoadCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.admanager.AdManagerAdRequest
+import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
+import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAdLoadCallback
+
+class ReactNativeGoogleMobileAdsRewardedInterstitialModuleImpl(reactContext: ReactApplicationContext?) :
+  ReactNativeGoogleMobileAdsFullScreenAdModule<RewardedInterstitialAd>(reactContext) {
+
+  override fun getAdEventName(): String {
+    return ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_REWARDED_INTERSTITIAL
+  }
+
+  fun rewardedInterstitialLoad(requestId: Int, adUnitId: String, adRequestOptions: ReadableMap) {
+    load(requestId, adUnitId, adRequestOptions)
+  }
+
+  fun rewardedInterstitialShow(
+    requestId: Int, adUnitId: String, showOptions: ReadableMap, promise: Promise
+  ) {
+    show(requestId, adUnitId, showOptions, promise)
+  }
+
+  override fun loadAd(
+    activity: Activity,
+    adUnitId: String,
+    adRequest: AdManagerAdRequest,
+    adLoadCallback: AdLoadCallback<RewardedInterstitialAd>
+  ) {
+    RewardedInterstitialAd.load(
+      activity,
+      adUnitId,
+      adRequest,
+      object :
+        RewardedInterstitialAdLoadCallback() {
+        override fun onAdLoaded(ad: RewardedInterstitialAd) {
+          adLoadCallback.onAdLoaded(ad)
+        }
+        override fun onAdFailedToLoad(error: LoadAdError) {
+          adLoadCallback.onAdFailedToLoad(error)
+        }
+      })
+  }
+
+}

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModule.kt
@@ -1,5 +1,6 @@
 package io.invertase.googlemobileads
 
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
@@ -9,19 +10,20 @@ class ReactNativeGoogleMobileAdsRewardedModule(reactContext: ReactApplicationCon
   private val instance: ReactNativeGoogleMobileAdsRewardedModuleImpl = ReactNativeGoogleMobileAdsRewardedModuleImpl(reactContext)
   override fun rewardedLoad(
     requestId: Double,
-    adUnitId: String?,
-    requestOptions: ReadableMap?
+    adUnitId: String,
+    requestOptions: ReadableMap
   ) {
-//    instance.rewardedLoad()
+    instance.rewardedLoad(requestId.toInt(), adUnitId,requestOptions)
   }
 
   override fun rewardedShow(
     requestId: Double,
-    adUnitId: String?,
+    adUnitId: String,
     showOptions: ReadableMap?,
-    promise: Promise?
+    promise: Promise
   ) {
-//    instance.rewardedShow()
+    val processedShowOptions = showOptions ?: Arguments.createMap()
+    instance.rewardedShow(requestId.toInt(),adUnitId, processedShowOptions , promise)
   }
   companion object {
     const val NAME = NativeRewardedModuleSpec.NAME

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModule.kt
@@ -1,74 +1,29 @@
 package io.invertase.googlemobileads
 
-/*
- * Copyright (c) 2016-present Invertase Limited & Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this library except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
-import android.app.Activity
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import com.google.android.gms.ads.AdLoadCallback
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.admanager.AdManagerAdRequest
-import com.google.android.gms.ads.rewarded.RewardedAd
-import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 
-class ReactNativeGoogleMobileAdsRewardedModule(reactContext: ReactApplicationContext?) :
-  ReactNativeGoogleMobileAdsFullScreenAdModule<RewardedAd>(reactContext, NAME) {
+class ReactNativeGoogleMobileAdsRewardedModule(reactContext: ReactApplicationContext?) : NativeRewardedModuleSpec(reactContext) {
 
-  override fun getAdEventName(): String {
-    return ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_REWARDED
-  }
-
-  @ReactMethod
-  fun rewardedLoad(requestId: Int, adUnitId: String, adRequestOptions: ReadableMap) {
-    load(requestId, adUnitId, adRequestOptions)
-  }
-
-  @ReactMethod
-  fun rewardedShow(
-    requestId: Int, adUnitId: String, showOptions: ReadableMap, promise: Promise
+  private val instance: ReactNativeGoogleMobileAdsRewardedModuleImpl = ReactNativeGoogleMobileAdsRewardedModuleImpl(reactContext)
+  override fun rewardedLoad(
+    requestId: Double,
+    adUnitId: String?,
+    requestOptions: ReadableMap?
   ) {
-    show(requestId, adUnitId, showOptions, promise)
+//    instance.rewardedLoad()
   }
 
-  override fun loadAd(
-    activity: Activity,
-    adUnitId: String,
-    adRequest: AdManagerAdRequest,
-    adLoadCallback: AdLoadCallback<RewardedAd>
+  override fun rewardedShow(
+    requestId: Double,
+    adUnitId: String?,
+    showOptions: ReadableMap?,
+    promise: Promise?
   ) {
-    RewardedAd.load(
-      activity,
-      adUnitId,
-      adRequest,
-      object :
-        RewardedAdLoadCallback() {
-        override fun onAdLoaded(ad: RewardedAd) {
-          adLoadCallback.onAdLoaded(ad)
-        }
-        override fun onAdFailedToLoad(error: LoadAdError) {
-          adLoadCallback.onAdFailedToLoad(error)
-        }
-      })
+//    instance.rewardedShow()
   }
-
   companion object {
-    const val NAME = "RNGoogleMobileAdsRewardedModule"
+    const val NAME = NativeRewardedModuleSpec.NAME
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModuleImpl.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModuleImpl.kt
@@ -60,6 +60,7 @@ class ReactNativeGoogleMobileAdsRewardedModuleImpl(reactContext: ReactApplicatio
         override fun onAdLoaded(ad: RewardedAd) {
           adLoadCallback.onAdLoaded(ad)
         }
+
         override fun onAdFailedToLoad(error: LoadAdError) {
           adLoadCallback.onAdFailedToLoad(error)
         }

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModuleImpl.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsRewardedModuleImpl.kt
@@ -1,0 +1,68 @@
+package io.invertase.googlemobileads
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import android.app.Activity
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.google.android.gms.ads.AdLoadCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.admanager.AdManagerAdRequest
+import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
+
+class ReactNativeGoogleMobileAdsRewardedModuleImpl(reactContext: ReactApplicationContext?) :
+  ReactNativeGoogleMobileAdsFullScreenAdModule<RewardedAd>(reactContext) {
+
+  override fun getAdEventName(): String {
+    return ReactNativeGoogleMobileAdsEvent.GOOGLE_MOBILE_ADS_EVENT_REWARDED
+  }
+
+  fun rewardedLoad(requestId: Int, adUnitId: String, adRequestOptions: ReadableMap) {
+    load(requestId, adUnitId, adRequestOptions)
+  }
+
+  fun rewardedShow(
+    requestId: Int, adUnitId: String, showOptions: ReadableMap, promise: Promise
+  ) {
+    show(requestId, adUnitId, showOptions, promise)
+  }
+
+  override fun loadAd(
+    activity: Activity,
+    adUnitId: String,
+    adRequest: AdManagerAdRequest,
+    adLoadCallback: AdLoadCallback<RewardedAd>
+  ) {
+    RewardedAd.load(
+      activity,
+      adUnitId,
+      adRequest,
+      object :
+        RewardedAdLoadCallback() {
+        override fun onAdLoaded(ad: RewardedAd) {
+          adLoadCallback.onAdLoaded(ad)
+        }
+        override fun onAdFailedToLoad(error: LoadAdError) {
+          adLoadCallback.onAdFailedToLoad(error)
+        }
+      })
+  }
+}

--- a/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeModule.java
@@ -26,15 +26,11 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nonnull;
 
-public class ReactNativeModule extends ReactContextBaseJavaModule implements ContextProvider {
-  private final TaskExecutorService executorService;
+public class ReactNativeModule implements ContextProvider {
+  private ReactApplicationContext context;
 
-  private String moduleName;
-
-  public ReactNativeModule(ReactApplicationContext reactContext, String moduleName) {
-    super(reactContext);
-    this.moduleName = moduleName;
-    this.executorService = new TaskExecutorService(getName());
+  public ReactNativeModule(ReactApplicationContext reactContext) {
+    this.context = reactContext;
   }
 
   public static void rejectPromiseWithCodeAndMessage(Promise promise, String code, String message) {
@@ -44,53 +40,17 @@ public class ReactNativeModule extends ReactContextBaseJavaModule implements Con
     promise.reject(code, message, userInfoMap);
   }
 
-  @Override
-  public void initialize() {
-    super.initialize();
-  }
-
   public ReactContext getContext() {
-    return getReactApplicationContext();
+    return context;
   }
 
-  public ExecutorService getExecutor() {
-    return executorService.getExecutor();
-  }
 
-  public ExecutorService getTransactionalExecutor() {
-    return executorService.getTransactionalExecutor();
-  }
-
-  public ExecutorService getTransactionalExecutor(String identifier) {
-    return executorService.getTransactionalExecutor(identifier);
-  }
-
-  @Override
-  public void invalidate() {
-    executorService.shutdown();
-  }
-
-  public void removeEventListeningExecutor(String identifier) {
-    String executorName = executorService.getExecutorName(true, identifier);
-    executorService.removeExecutor(executorName);
-  }
 
   public Context getApplicationContext() {
-    return getReactApplicationContext().getApplicationContext();
+    return context.getApplicationContext();
   }
 
   public Activity getActivity() {
-    return getCurrentActivity();
-  }
-
-  @Nonnull
-  @Override
-  public String getName() {
-    return moduleName;
-  }
-
-  @Override
-  public Map<String, Object> getConstants() {
-    return new HashMap<>();
+    return context.getCurrentActivity();
   }
 }

--- a/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeModule.java
+++ b/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeModule.java
@@ -19,11 +19,15 @@ package io.invertase.googlemobileads.common;
 
 import android.app.Activity;
 import android.content.Context;
+
 import com.facebook.react.bridge.*;
+
 import io.invertase.googlemobileads.interfaces.ContextProvider;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+
 import javax.annotation.Nonnull;
 
 public class ReactNativeModule implements ContextProvider {
@@ -43,7 +47,6 @@ public class ReactNativeModule implements ContextProvider {
   public ReactContext getContext() {
     return context;
   }
-
 
 
   public Context getApplicationContext() {


### PR DESCRIPTION
### Description

This PR migrates key Android components to React Native’s New Architecture (TurboModules/Fabric) and updates documentation to reflect the current migration status.

- Implemented native specs and refactored modules for New Architecture compatibility.
- Confirmed Banner Ads are using a Fabric Native Component via codegen.
- Migrated Mobile Ads SDK methods and Full Screen Ad modules (App Open, Interstitial, Rewarded, Rewarded Interstitial) to the New Architecture. fv
- Updated the Android rows in the README’s “Migrating to the New Architecture Status” table.

### Related issues

- N/A

### Release Summary

Android migration to New Architecture for core ads modules; documentation updated to reflect current status.

### Checklist

- I read the Contributor Guide and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Verified that Android Banner component renders via Fabric using the codegen native component (`GoogleMobileAdsBannerViewNativeComponent`) and manager (`ReactNativeGoogleMobileAdsBannerAdViewManager`).
- Validated Full Screen Ads lifecycle under the new TurboModule implementations:
  - App Open, Interstitial, Rewarded, Rewarded Interstitial load/show/dismiss flows.
- Ensured README status accurately reflects current migration state.

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter