### PR TITLE
style(types): remove deprecated uses of non-root react-native imports WIP

### DIFF
--- a/src/internal/SharedEventEmitter.ts
+++ b/src/internal/SharedEventEmitter.ts
@@ -15,6 +15,6 @@
  *
  */
 
-import EventEmitter from 'react-native/Libraries/vendor/emitter/EventEmitter';
+import { NativeEventEmitter } from 'react-native';
 
-export const SharedEventEmitter: EventEmitter = new EventEmitter();
+export const SharedEventEmitter: NativeEventEmitter = new NativeEventEmitter();

--- a/src/specs/components/GoogleMobileAdsBannerViewNativeComponent.ts
+++ b/src/specs/components/GoogleMobileAdsBannerViewNativeComponent.ts
@@ -17,29 +17,27 @@
 
 import type * as React from 'react';
 import type { HostComponent, ViewProps } from 'react-native';
-import type { BubblingEventHandler, Float } from 'react-native/Libraries/Types/CodegenTypes';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
+import { codegenNativeCommands, codegenNativeComponent, CodegenTypes } from 'react-native';
 
 export type NativeEvent = {
   type: string;
-  width?: Float;
-  height?: Float;
+  width?: CodegenTypes.Float;
+  height?: CodegenTypes.Float;
   code?: string;
   message?: string;
   name?: string;
   data?: string;
   currency?: string;
-  precision?: Float;
-  value?: Float;
+  precision?: CodegenTypes.Float;
+  value?: CodegenTypes.Float;
 };
 
 export interface NativeProps extends ViewProps {
-  sizeConfig: { sizes: string[]; maxHeight?: Float; width?: Float };
+  sizeConfig: { sizes: string[]; maxHeight?: CodegenTypes.Float; width?: CodegenTypes.Float };
   unitId: string;
   request: string;
   manualImpressionsEnabled: boolean;
-  onNativeEvent: BubblingEventHandler<NativeEvent>;
+  onNativeEvent: CodegenTypes.BubblingEventHandler<NativeEvent>;
 }
 
 export type ComponentType = HostComponent<NativeProps>;

--- a/src/specs/components/GoogleMobileAdsMediaViewNativeComponent.ts
+++ b/src/specs/components/GoogleMobileAdsMediaViewNativeComponent.ts
@@ -16,7 +16,7 @@
  */
 
 import type { HostComponent, ViewProps } from 'react-native';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { codegenNativeComponent } from 'react-native';
 
 export interface NativeProps extends ViewProps {
   responseId: string;

--- a/src/specs/components/GoogleMobileAdsNativeViewNativeComponent.ts
+++ b/src/specs/components/GoogleMobileAdsNativeViewNativeComponent.ts
@@ -17,9 +17,7 @@
 
 import type * as React from 'react';
 import type { HostComponent, ViewProps } from 'react-native';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
-import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
+import { codegenNativeComponent, codegenNativeCommands, CodegenTypes } from 'react-native';
 
 export interface NativeProps extends ViewProps {
   responseId: string;
@@ -29,10 +27,11 @@ type NativeViewComponentType = HostComponent<NativeProps>;
 
 interface NativeCommands {
   registerAsset: (
+    // TODO - we may remove this deprecation and shift to React.ComponentRef when RN0.84 is our minimum
     // eslint-disable-next-line @typescript-eslint/no-deprecated -- https://github.com/facebook/react-native/issues/54272
     viewRef: React.ElementRef<NativeViewComponentType>,
     assetType: string,
-    reactTag: Int32,
+    reactTag: CodegenTypes.Int32,
   ) => void;
 }
 

--- a/src/specs/modules/NativeAppOpenModule.ts
+++ b/src/specs/modules/NativeAppOpenModule.ts
@@ -16,11 +16,19 @@
  */
 
 import { TurboModule, TurboModuleRegistry } from 'react-native';
-import { Double, UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
+import { CodegenTypes } from 'react-native';
 
 export interface Spec extends TurboModule {
-  appOpenLoad(requestId: Double, adUnitId: string, requestOptions: UnsafeObject): void;
-  appOpenShow(requestId: Double, adUnitId: string, showOptions?: UnsafeObject): Promise<void>;
+  appOpenLoad(
+    requestId: CodegenTypes.Double,
+    adUnitId: string,
+    requestOptions: CodegenTypes.UnsafeObject,
+  ): void;
+  appOpenShow(
+    requestId: CodegenTypes.Double,
+    adUnitId: string,
+    showOptions?: CodegenTypes.UnsafeObject,
+  ): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNGoogleMobileAdsAppOpenModule');

--- a/src/specs/modules/NativeGoogleMobileAdsModule.ts
+++ b/src/specs/modules/NativeGoogleMobileAdsModule.ts
@@ -17,13 +17,13 @@
 
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
-import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
+import type { CodegenTypes } from 'react-native';
 
 import { AdapterStatus } from '../../types';
 
 export interface Spec extends TurboModule {
   initialize(): Promise<AdapterStatus[]>;
-  setRequestConfiguration(requestConfiguration?: UnsafeObject): Promise<void>;
+  setRequestConfiguration(requestConfiguration?: CodegenTypes.UnsafeObject): Promise<void>;
   openAdInspector(): Promise<void>;
   openDebugMenu(adUnit: string): void;
   setAppVolume(volume: number): void;

--- a/src/specs/modules/NativeInterstitialModule.ts
+++ b/src/specs/modules/NativeInterstitialModule.ts
@@ -16,11 +16,19 @@
  */
 
 import { TurboModule, TurboModuleRegistry } from 'react-native';
-import { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
+import { CodegenTypes } from 'react-native';
 
 export interface Spec extends TurboModule {
-  interstitialLoad(requestId: number, adUnitId: string, requestOptions: UnsafeObject): void;
-  interstitialShow(requestId: number, adUnitId: string, showOptions?: UnsafeObject): Promise<void>;
+  interstitialLoad(
+    requestId: number,
+    adUnitId: string,
+    requestOptions: CodegenTypes.UnsafeObject,
+  ): void;
+  interstitialShow(
+    requestId: number,
+    adUnitId: string,
+    showOptions?: CodegenTypes.UnsafeObject,
+  ): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNGoogleMobileAdsInterstitialModule');

--- a/src/specs/modules/NativeRewardedInterstitialModule.ts
+++ b/src/specs/modules/NativeRewardedInterstitialModule.ts
@@ -16,14 +16,18 @@
  */
 
 import { TurboModule, TurboModuleRegistry } from 'react-native';
-import { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
+import { CodegenTypes } from 'react-native';
 
 export interface Spec extends TurboModule {
-  rewardedInterstitialLoad(requestId: number, adUnitId: string, requestOptions: UnsafeObject): void;
+  rewardedInterstitialLoad(
+    requestId: number,
+    adUnitId: string,
+    requestOptions: CodegenTypes.UnsafeObject,
+  ): void;
   rewardedInterstitialShow(
     requestId: number,
     adUnitId: string,
-    showOptions?: UnsafeObject,
+    showOptions?: CodegenTypes.UnsafeObject,
   ): Promise<void>;
 }
 

--- a/src/specs/modules/NativeRewardedModule.ts
+++ b/src/specs/modules/NativeRewardedModule.ts
@@ -16,11 +16,19 @@
  */
 
 import { TurboModule, TurboModuleRegistry } from 'react-native';
-import { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
+import { CodegenTypes } from 'react-native';
 
 export interface Spec extends TurboModule {
-  rewardedLoad(requestId: number, adUnitId: string, requestOptions: UnsafeObject): void;
-  rewardedShow(requestId: number, adUnitId: string, showOptions?: UnsafeObject): Promise<void>;
+  rewardedLoad(
+    requestId: number,
+    adUnitId: string,
+    requestOptions: CodegenTypes.UnsafeObject,
+  ): void;
+  rewardedShow(
+    requestId: number,
+    adUnitId: string,
+    showOptions?: CodegenTypes.UnsafeObject,
+  ): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNGoogleMobileAdsRewardedModule');


### PR DESCRIPTION
### Description

react-native is deprecating uses of deep imports from their types, they are movings towards exporting everything you need via the `react-native` export directly

This PR attempts to move to that API

**Note:** I observed some incorrect test behavior after adopting this, related to the EventEmitter port. I had to switch to NativeEventEmitter as a type / object and it appears to emit the events, *but not at the right time*

Specifically, the problem I saw was:

- open e2e app via `tests:android:run` after installing and building etc
- open a Terminal and run `adb logcat | grep ReactNatieJS` so you can see the hook state changing as events happen
- click on any of the "Hook" tests, like the Interstitial one
- let the interstitial add load, then click to show it, wait for a moment, then click to close it and return to app

Expected: all the events are emitted as they happen and the hook updates (and logs) that state changed
Actual: it appeared the events sometimes - and most frequently with the "closed" state change, did *not* get emitted on time but were delayed. Specifically, that close state change did not show up when I closed it but it *did* show up for the interstitial hook test *after I opened one of the other hook tests*

Are the events queueing somewhere so they emit in a batch ? Is there something else going on ?

I don't know.

Future investigation should involve putting some logging into the native code to log when the native code emits the events into the react-native emitter chain, to identify which macro chunk of the system is failing, then go from there

### Related issues

### Release Summary

Don't merge until the events thing is fixed

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

watch `ReactNativeJS` logcat tags while testing hook state changes to make sure event emission is working

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
