### PR TITLE
fix(native, ios): fix bridgeless mode compatibility for native ad views

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
@@ -52,11 +52,9 @@ using namespace facebook::react;
 
 - (instancetype)initWithFrame:(CGRect)frame {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsBannerViewProps>();
+    static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsMediaViewProps>();
     _props = defaultProps;
 
-    _bridge = [RCTBridge currentBridge];
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
     _mediaView = [[GADMediaView alloc] init];
     _contentMode = UIViewContentModeScaleAspectFill;
     self.contentView = _mediaView;
@@ -110,9 +108,17 @@ using namespace facebook::react;
 
 #pragma mark - Common logics
 
+- (RNGoogleMobileAdsNativeModule *)resolveNativeModule {
+  RCTBridge *bridge = [RCTBridge currentBridge];
+  if (bridge) {
+    return [bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+  }
+  return [RNGoogleMobileAdsNativeModule sharedInstance];
+}
+
 - (void)setResponseId:(NSString *)responseId {
   _responseId = responseId;
-  GADNativeAd *nativeAd = [_nativeModule nativeAdForResponseId:responseId];
+  GADNativeAd *nativeAd = [[self resolveNativeModule] nativeAdForResponseId:responseId];
   _mediaView.mediaContent = nativeAd.mediaContent;
   _mediaView.contentMode = _contentMode;
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.h
@@ -30,6 +30,7 @@
 @interface RNGoogleMobileAdsNativeModule : RCTEventEmitter <RCTBridgeModule>
 #endif
 
++ (instancetype)sharedInstance;
 - (GADNativeAd *)nativeAdForResponseId:(NSString *)responseId;
 
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
@@ -59,9 +59,16 @@ RCT_EXPORT_MODULE();
 }
 #endif
 
+static __weak RNGoogleMobileAdsNativeModule *_sharedInstance = nil;
+
++ (instancetype)sharedInstance {
+  return _sharedInstance;
+}
+
 - (instancetype)init {
   if (self = [super init]) {
     _adHolders = [NSMutableDictionary dictionary];
+    _sharedInstance = self;
   }
   return self;
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
@@ -57,8 +57,6 @@ using namespace facebook::react;
     static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsNativeViewProps>();
     _props = defaultProps;
 
-    _bridge = [RCTBridge currentBridge];
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
     _nativeAdView = [[GADNativeAdView alloc] init];
     self.contentView = _nativeAdView;
   }
@@ -137,9 +135,17 @@ using namespace facebook::react;
 
 #pragma mark - Common logics
 
+- (RNGoogleMobileAdsNativeModule *)resolveNativeModule {
+  RCTBridge *bridge = [RCTBridge currentBridge];
+  if (bridge) {
+    return [bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+  }
+  return [RNGoogleMobileAdsNativeModule sharedInstance];
+}
+
 - (void)setResponseId:(NSString *)responseId {
   _responseId = responseId;
-  _nativeAd = [_nativeModule nativeAdForResponseId:responseId];
+  _nativeAd = [[self resolveNativeModule] nativeAdForResponseId:responseId];
   [self reloadAd];
 }
 


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Fix iOS native ad views crashing/not working in bridgeless (New Architecture) mode.

- Fix incorrect props type in `RNGoogleMobileAdsMediaView` (`BannerViewProps` → `MediaViewProps`)
- Add `sharedInstance` weak singleton accessor to `RNGoogleMobileAdsNativeModule` for bridgeless module resolution
- Update `RNGoogleMobileAdsNativeView` and `RNGoogleMobileAdsMediaView` to fall back to `sharedInstance` when `RCTBridge` is nil

> [!Note] 
> The weak singleton approach is just a workaround to allow usage with new architecture. A future improvement would be to use `RCTModuleRegistry` for proper bridgeless module resolution. 

### Related issues

N/A

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->
iOS native ad views now work correctly in bridgeless (New Architecture) mode.
  
### Checklist

- I read the [Contributor Guide](	)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

- Verified native ads load and render correctly on iOS in bridgeless mode
- Verified native ads still work on iOS with the classic bridge
- Verified `GADMediaView` renders media content properly in both modes

---

🔥 
