### PR TITLE
fix: add requiresMainQueueSetup for RN warning

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
@@ -48,6 +48,10 @@ RCT_EXPORT_MODULE();
   return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params {


### PR DESCRIPTION
### Description

React Native is showing a warning for the `RNGoogleMobileAdsNativeModule` native module:
This warning appears because the native module overrides `init`, but does not explicitly declare whether it should be initialized on the main thread or background thread.
A previous commit ([fix: warning requiresMainQueueSetup](https://github.com/invertase/react-native-google-mobile-ads/commit/b6c2ee7eed3d1967f49f7a2212d58cf1c1af9a38)) addressed the same class of warning by adding explicit initialization queue declarations to other native modules.
<img width="692" height="52" alt="截圖 2026-04-16 上午11 22 46" src="https://github.com/user-attachments/assets/2943801f-6b74-4c9a-9bec-f8102cf16ae2" />



### Related issues

Fixes #723

### Release Summary

Fix React Native initialization warning for native module RNGoogleMobileAdsNativeModule.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter

---
🔥