### PR TITLE
fix(ios): resolve native ad module under bridgeless React Native

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
@@ -52,11 +52,12 @@ using namespace facebook::react;
 
 - (instancetype)initWithFrame:(CGRect)frame {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsBannerViewProps>();
+    static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsMediaViewProps>();
     _props = defaultProps;
 
     _bridge = [RCTBridge currentBridge];
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class]
+                        ?: [RNGoogleMobileAdsNativeModule sharedInstance];
     _mediaView = [[GADMediaView alloc] init];
     _contentMode = UIViewContentModeScaleAspectFill;
     self.contentView = _mediaView;
@@ -100,7 +101,8 @@ using namespace facebook::react;
 - (instancetype)initWithBridge:(RCTBridge *)bridge {
   if (self = [super init]) {
     _bridge = bridge;
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class]
+                        ?: [RNGoogleMobileAdsNativeModule sharedInstance];
     _mediaView = self;
   }
   return self;

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.h
@@ -32,4 +32,10 @@
 
 - (GADNativeAd *)nativeAdForResponseId:(NSString *)responseId;
 
+// Bridgeless-mode escape hatch: under React Native bridgeless mode
+// [RCTBridge currentBridge] returns nil, so views that fetch this module via
+// `moduleForClass:` get a nil reference. The Fabric views fall back to this
+// singleton, which captures the module instance on init.
++ (instancetype)sharedInstance;
+
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
@@ -38,11 +38,17 @@ typedef void (^RNGMANativeAdLoadCompletionHandler)(GADNativeAd *_Nullable native
 
 @end
 
+static __weak RNGoogleMobileAdsNativeModule *_RNGMASharedInstance = nil;
+
 @implementation RNGoogleMobileAdsNativeModule {
   NSMutableDictionary<NSString *, RNGMANativeAdHolder *> *_adHolders;
 }
 
 RCT_EXPORT_MODULE();
+
++ (instancetype)sharedInstance {
+  return _RNGMASharedInstance;
+}
 
 - (dispatch_queue_t)methodQueue {
   return dispatch_get_main_queue();
@@ -66,6 +72,7 @@ RCT_EXPORT_MODULE();
 - (instancetype)init {
   if (self = [super init]) {
     _adHolders = [NSMutableDictionary dictionary];
+    _RNGMASharedInstance = self;
   }
   return self;
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
@@ -58,7 +58,8 @@ using namespace facebook::react;
     _props = defaultProps;
 
     _bridge = [RCTBridge currentBridge];
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class]
+                        ?: [RNGoogleMobileAdsNativeModule sharedInstance];
     _nativeAdView = [[GADNativeAdView alloc] init];
     self.contentView = _nativeAdView;
   }
@@ -127,7 +128,8 @@ using namespace facebook::react;
 - (instancetype)initWithBridge:(RCTBridge *)bridge {
   if (self = [super init]) {
     _bridge = bridge;
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class]
+                        ?: [RNGoogleMobileAdsNativeModule sharedInstance];
     _nativeAdView = self;
   }
   return self;


### PR DESCRIPTION
### Description

Under React Native bridgeless mode (the default once Hermes V1 is enabled in RN 0.85 / Expo SDK 56), `[RCTBridge currentBridge]` returns `nil`. Both `RNGoogleMobileAdsMediaView` and `RNGoogleMobileAdsNativeView` capture their `_nativeModule` reference via `[bridge moduleForClass:]` at init time and end up with `nil`. The later call `[_nativeModule nativeAdForResponseId:responseId]` then returns `nil` and the SDK is never given the `GADNativeAd` to bind.

**User-visible symptom:** `NativeMediaView` renders blank — no image, no video, no error. Text assets (headline, body, CTA) still render because their content is set from JS, not by the native SDK, which makes the bug easy to mistake for a layout issue.

#### Diagnostic trace

With instrumentation on `setResponseId:` showing `bridge`, `nativeModule`, and `nativeAd`:

\`\`\`
[RNGMA-MediaView] setResponseId responseId=KPYEavTTJ7PArNcPl9eAmAg bridge=(null) nativeModule=(null) nativeAd=(null) mediaContent=(null) ...
\`\`\`

After the fix:

\`\`\`
[RNGMA-MediaView] setResponseId responseId=0_YEapmdAdaArNcP77CKoQY bridge=(null) nativeModule=<RNGoogleMobileAdsNativeModule: 0x6000015a8d20> nativeAd=<GADNativeAd: 0x600002a591f0> mediaContent=<GADMediaContent: 0x600000526720> aspectRatio=1.777778 hasVideo=1 ...
\`\`\`

#### Fix

* \`RNGoogleMobileAdsNativeModule\` captures \`self\` into a \`__weak\` static on \`init\` and exposes \`+sharedInstance\`.
* The Fabric Media/Native views (and their Paper-mode \`initWithBridge:\` counterparts, defensively) fall back to that singleton when the bridge lookup yields \`nil\`. When the bridge is present, the original code path is unchanged.

It's a strict superset of existing behavior, so it should be safe to merge without affecting older RN versions or non-bridgeless apps.

#### Secondary fix

Also corrects a latent typo in \`RNGoogleMobileAdsMediaView.mm\` where the Fabric \`initWithFrame:\` declared \`defaultProps\` as \`RNGoogleMobileAdsBannerViewProps\` instead of \`…MediaViewProps\`. The two generated structs have incompatible field layouts, so the subsequent \`static_pointer_cast<MediaViewProps>(_props)\` in \`updateProps\` reads garbage bytes from the banner struct's \`sizeConfig\` field as if they were \`responseId\`. Depending on RN version that garbage may compare equal to the real incoming \`responseId\` and suppress the \`setResponseId:\` call entirely, or may compare unequal but cause undefined behavior at construction.

### Related issues

None filed — happy to open one with the diagnostic write-up if useful.

### Release Summary

Fixes native ad media (\`NativeMediaView\`) rendering blank on iOS when React Native is running in bridgeless mode (RN 0.85+ / Expo SDK 56 with Hermes V1).

### Checklist

- I read the Contributor Guide and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] \`Android\`
  - [x] \`iOS\`
- My change includes tests;
  - [ ] \`e2e\` tests added or updated in \`__tests__e2e__\`
  - [ ] \`jest\` tests added or updated in \`__tests__\`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Reproduced on an Expo SDK 56 app with \`react-native-google-mobile-ads@16.3.3\`, RN 0.85.3, iOS 16.4 deployment target, iPhone 17 simulator, Hermes V1 enabled (which forces bridgeless). Native ad headlines rendered but \`NativeMediaView\` was blank. After applying this patch and reinstalling pods, video and image native ads render correctly. \`NativeAdView\` impression / click handling continues to work (verified via AdMob console).

No existing e2e or unit tests in this repo cover bridgeless module lookup, so this PR doesn't add tests — happy to do so if there's a preferred pattern.