### PR TITLE
fix(native-ads): return image assets and stabilize iOS native ad views

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeModule.kt
@@ -67,6 +67,16 @@ class ReactNativeGoogleMobileAdsNativeModule(
       } ?: run {
         data.putNull("icon")
       }
+      val imagesArray = Arguments.createArray()
+      nativeAd.images.forEach { image ->
+        image.uri?.let { uri ->
+          val imageMap = Arguments.createMap()
+          imageMap.putString("url", uri.toString())
+          imageMap.putDouble("scale", image.scale)
+          imagesArray.pushMap(imageMap)
+        }
+      }
+      data.putArray("images", imagesArray)
       val mediaContent = Arguments.createMap()
       nativeAd.mediaContent?.let {
         mediaContent.putDouble("aspectRatio", it.aspectRatio.toDouble())

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
@@ -52,11 +52,11 @@ using namespace facebook::react;
 
 - (instancetype)initWithFrame:(CGRect)frame {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsBannerViewProps>();
+    static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsMediaViewProps>();
     _props = defaultProps;
 
     _bridge = [RCTBridge currentBridge];
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+    _nativeModule = [self nativeModule];
     _mediaView = [[GADMediaView alloc] init];
     _contentMode = UIViewContentModeScaleAspectFill;
     self.contentView = _mediaView;
@@ -100,7 +100,7 @@ using namespace facebook::react;
 - (instancetype)initWithBridge:(RCTBridge *)bridge {
   if (self = [super init]) {
     _bridge = bridge;
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+    _nativeModule = [self nativeModule];
     _mediaView = self;
   }
   return self;
@@ -110,9 +110,25 @@ using namespace facebook::react;
 
 #pragma mark - Common logics
 
+- (RNGoogleMobileAdsNativeModule *)nativeModule {
+  if (_nativeModule != nil) {
+    return _nativeModule;
+  }
+
+  if (_bridge != nil) {
+    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+  }
+
+  if (_nativeModule == nil) {
+    _nativeModule = [RNGoogleMobileAdsNativeModule sharedInstance];
+  }
+
+  return _nativeModule;
+}
+
 - (void)setResponseId:(NSString *)responseId {
   _responseId = responseId;
-  GADNativeAd *nativeAd = [_nativeModule nativeAdForResponseId:responseId];
+  GADNativeAd *nativeAd = [[self nativeModule] nativeAdForResponseId:responseId];
   _mediaView.mediaContent = nativeAd.mediaContent;
   _mediaView.contentMode = _contentMode;
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.h
@@ -32,4 +32,6 @@
 
 - (GADNativeAd *)nativeAdForResponseId:(NSString *)responseId;
 
++ (RNGoogleMobileAdsNativeModule *)sharedInstance;
+
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
@@ -42,6 +42,8 @@ typedef void (^RNGMANativeAdLoadCompletionHandler)(GADNativeAd *_Nullable native
   NSMutableDictionary<NSString *, RNGMANativeAdHolder *> *_adHolders;
 }
 
+static __weak RNGoogleMobileAdsNativeModule *_sharedInstance = nil;
+
 RCT_EXPORT_MODULE();
 
 - (dispatch_queue_t)methodQueue {
@@ -66,8 +68,13 @@ RCT_EXPORT_MODULE();
 - (instancetype)init {
   if (self = [super init]) {
     _adHolders = [NSMutableDictionary dictionary];
+    _sharedInstance = self;
   }
   return self;
+}
+
++ (RNGoogleMobileAdsNativeModule *)sharedInstance {
+  return _sharedInstance;
 }
 
 RCT_EXPORT_METHOD(
@@ -95,6 +102,16 @@ RCT_EXPORT_METHOD(
 
         [_adHolders setValue:adHolder forKey:responseId];
 
+        NSMutableArray *imagesArray = [NSMutableArray array];
+        for (GADNativeAdImage *image in nativeAd.images) {
+          if (image.imageURL != nil) {
+            [imagesArray addObject:(@{
+              @"url" : image.imageURL.absoluteString,
+              @"scale" : @(image.scale)
+            })];
+          }
+        }
+
         resolve(@{
           @"responseId" : responseId,
           @"advertiser" : nativeAd.advertiser ?: [NSNull null],
@@ -107,6 +124,7 @@ RCT_EXPORT_METHOD(
           @"icon" : (nativeAd.icon && nativeAd.icon.imageURL != nil)
               ? @{@"scale" : @(nativeAd.icon.scale), @"url" : nativeAd.icon.imageURL.absoluteString}
               : [NSNull null],
+          @"images" : imagesArray,
           @"mediaContent" : @{
             @"aspectRatio" : @(nativeAd.mediaContent.aspectRatio),
             @"hasVideoContent" : @(nativeAd.mediaContent.hasVideoContent),
@@ -134,6 +152,9 @@ RCT_EXPORT_METHOD(destroy
     [adHolder dispose];
   }
   [_adHolders removeAllObjects];
+  if (_sharedInstance == self) {
+    _sharedInstance = nil;
+  }
 }
 
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
@@ -58,7 +58,7 @@ using namespace facebook::react;
     _props = defaultProps;
 
     _bridge = [RCTBridge currentBridge];
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+    _nativeModule = [self nativeModule];
     _nativeAdView = [[GADNativeAdView alloc] init];
     self.contentView = _nativeAdView;
   }
@@ -127,7 +127,7 @@ using namespace facebook::react;
 - (instancetype)initWithBridge:(RCTBridge *)bridge {
   if (self = [super init]) {
     _bridge = bridge;
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+    _nativeModule = [self nativeModule];
     _nativeAdView = self;
   }
   return self;
@@ -137,9 +137,25 @@ using namespace facebook::react;
 
 #pragma mark - Common logics
 
+- (RNGoogleMobileAdsNativeModule *)nativeModule {
+  if (_nativeModule != nil) {
+    return _nativeModule;
+  }
+
+  if (_bridge != nil) {
+    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
+  }
+
+  if (_nativeModule == nil) {
+    _nativeModule = [RNGoogleMobileAdsNativeModule sharedInstance];
+  }
+
+  return _nativeModule;
+}
+
 - (void)setResponseId:(NSString *)responseId {
   _responseId = responseId;
-  _nativeAd = [_nativeModule nativeAdForResponseId:responseId];
+  _nativeAd = [[self nativeModule] nativeAdForResponseId:responseId];
   [self reloadAd];
 }
 


### PR DESCRIPTION
### Description

This PR fixes two native ad issues:

- Returns native ad image assets from Android and iOS via the existing `NativeAd.images` field.
- Improves iOS native ad view stability by resolving the native module through a shared module fallback when the bridge lookup is unavailable.

The TypeScript API already exposes `images: Array<NativeAdImage> | null`, but the native loaders were not populating it. This change fills that native response data on both platforms.

On iOS, `RNGoogleMobileAdsNativeView` and `RNGoogleMobileAdsMediaView` can be initialized in paths where `_bridge moduleForClass:` does not return the native module. Falling back to the shared module instance avoids nil native module access when binding native ads by `responseId`.

### Related issues

N/A

### Release Summary

Native ads now return image assets on Android and iOS, and iOS native ad views are more stable when resolving loaded ads.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Applied the change in a local app using native ads.
- Verified iOS native ads no longer crash when rendering native ad/media views.
- Verified native ad image assets are available through `nativeAd.images`.
- Ran `git diff --check`.

Note: TypeScript types already included `NativeAd.images`, so no type shape change was required.