### PR TITLE
fix(ios): bridgeless mode compatibility for native ads

### DIFF
--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
@@ -104,6 +104,9 @@ using namespace facebook::react;
 - (void)setResponseId:(NSString *)responseId {
   _responseId = [responseId copy];
   GADNativeAd *nativeAd = [RNGoogleMobileAdsNativeAdRegistry nativeAdForResponseId:responseId];
+  if (nativeAd == nil) {
+    return;
+  }
   _mediaView.mediaContent = nativeAd.mediaContent;
   _mediaView.contentMode = _contentMode;
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsMediaView.mm
@@ -16,7 +16,7 @@
  */
 
 #import "RNGoogleMobileAdsMediaView.h"
-#import "RNGoogleMobileAdsNativeModule.h"
+#import "RNGoogleMobileAdsNativeAdRegistry.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <react/renderer/components/RNGoogleMobileAdsSpec/ComponentDescriptors.h>
@@ -27,10 +27,6 @@
 #import "RCTFabricComponentsPlugins.h"
 #endif
 
-@interface RCTBridge (Private)
-+ (RCTBridge *)currentBridge;
-@end
-
 #ifdef RCT_NEW_ARCH_ENABLED
 using namespace facebook::react;
 
@@ -39,8 +35,6 @@ using namespace facebook::react;
 #endif
 
 @implementation RNGoogleMobileAdsMediaView {
-  __weak RCTBridge *_bridge;
-  __weak RNGoogleMobileAdsNativeModule *_nativeModule;
   GADMediaView *_mediaView;
   UIViewContentMode _contentMode;
 }
@@ -52,11 +46,9 @@ using namespace facebook::react;
 
 - (instancetype)initWithFrame:(CGRect)frame {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsBannerViewProps>();
+    static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsMediaViewProps>();
     _props = defaultProps;
 
-    _bridge = [RCTBridge currentBridge];
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
     _mediaView = [[GADMediaView alloc] init];
     _contentMode = UIViewContentModeScaleAspectFill;
     self.contentView = _mediaView;
@@ -99,9 +91,8 @@ using namespace facebook::react;
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge {
   if (self = [super init]) {
-    _bridge = bridge;
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
     _mediaView = self;
+    _contentMode = UIViewContentModeScaleAspectFill;
   }
   return self;
 }
@@ -111,8 +102,8 @@ using namespace facebook::react;
 #pragma mark - Common logics
 
 - (void)setResponseId:(NSString *)responseId {
-  _responseId = responseId;
-  GADNativeAd *nativeAd = [_nativeModule nativeAdForResponseId:responseId];
+  _responseId = [responseId copy];
+  GADNativeAd *nativeAd = [RNGoogleMobileAdsNativeAdRegistry nativeAdForResponseId:responseId];
   _mediaView.mediaContent = nativeAd.mediaContent;
   _mediaView.contentMode = _contentMode;
 }

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeAdRegistry.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeAdRegistry.h
@@ -25,7 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setNativeAd:(GADNativeAd *)nativeAd forResponseId:(NSString *)responseId;
 + (nullable GADNativeAd *)nativeAdForResponseId:(NSString *)responseId;
 + (void)removeNativeAdForResponseId:(NSString *)responseId;
-+ (void)removeAllNativeAds;
 
 @end
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeAdRegistry.h
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeAdRegistry.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+#import <GoogleMobileAds/GADNativeAd.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNGoogleMobileAdsNativeAdRegistry : NSObject
+
++ (void)setNativeAd:(GADNativeAd *)nativeAd forResponseId:(NSString *)responseId;
++ (nullable GADNativeAd *)nativeAdForResponseId:(NSString *)responseId;
++ (void)removeNativeAdForResponseId:(NSString *)responseId;
++ (void)removeAllNativeAds;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeAdRegistry.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeAdRegistry.mm
@@ -57,10 +57,4 @@ static NSMapTable<NSString *, GADNativeAd *> *_nativeAds;
   }
 }
 
-+ (void)removeAllNativeAds {
-  @synchronized(self) {
-    [_nativeAds removeAllObjects];
-  }
-}
-
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeAdRegistry.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeAdRegistry.mm
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import "RNGoogleMobileAdsNativeAdRegistry.h"
+
+@implementation RNGoogleMobileAdsNativeAdRegistry
+
+static NSMapTable<NSString *, GADNativeAd *> *_nativeAds;
+
++ (void)initialize {
+  if (self == [RNGoogleMobileAdsNativeAdRegistry class]) {
+    _nativeAds = [NSMapTable strongToStrongObjectsMapTable];
+  }
+}
+
++ (void)setNativeAd:(GADNativeAd *)nativeAd forResponseId:(NSString *)responseId {
+  if (responseId.length == 0 || nativeAd == nil) {
+    return;
+  }
+
+  @synchronized(self) {
+    [_nativeAds setObject:nativeAd forKey:responseId];
+  }
+}
+
++ (nullable GADNativeAd *)nativeAdForResponseId:(NSString *)responseId {
+  if (responseId.length == 0) {
+    return nil;
+  }
+
+  @synchronized(self) {
+    return [_nativeAds objectForKey:responseId];
+  }
+}
+
++ (void)removeNativeAdForResponseId:(NSString *)responseId {
+  if (responseId.length == 0) {
+    return;
+  }
+
+  @synchronized(self) {
+    [_nativeAds removeObjectForKey:responseId];
+  }
+}
+
++ (void)removeAllNativeAds {
+  @synchronized(self) {
+    [_nativeAds removeAllObjects];
+  }
+}
+
+@end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
@@ -19,6 +19,7 @@
 
 #import "RNGoogleMobileAdsNativeModule.h"
 #import "RNGoogleMobileAdsCommon.h"
+#import "RNGoogleMobileAdsNativeAdRegistry.h"
 
 typedef void (^RNGMANativeAdLoadCompletionHandler)(GADNativeAd *_Nullable nativeAd,
                                                    NSError *_Nullable error);
@@ -94,6 +95,7 @@ RCT_EXPORT_METHOD(
         }
 
         [_adHolders setValue:adHolder forKey:responseId];
+        [RNGoogleMobileAdsNativeAdRegistry setNativeAd:nativeAd forResponseId:responseId];
 
         resolve(@{
           @"responseId" : responseId,
@@ -118,14 +120,15 @@ RCT_EXPORT_METHOD(
 
 RCT_EXPORT_METHOD(destroy
                   : (NSString *)responseId {
-                    if (responseId) {
-                      [[_adHolders valueForKey:responseId] dispose];
+                    if (responseId.length > 0) {
+                      [[_adHolders objectForKey:responseId] dispose];
                       [_adHolders removeObjectForKey:responseId];
+                      [RNGoogleMobileAdsNativeAdRegistry removeNativeAdForResponseId:responseId];
                     }
                   });
 
 - (GADNativeAd *)nativeAdForResponseId:(NSString *)responseId {
-  return [_adHolders valueForKey:responseId].nativeAd;
+  return [RNGoogleMobileAdsNativeAdRegistry nativeAdForResponseId:responseId];
 }
 
 - (void)dealloc {
@@ -134,6 +137,7 @@ RCT_EXPORT_METHOD(destroy
     [adHolder dispose];
   }
   [_adHolders removeAllObjects];
+  [RNGoogleMobileAdsNativeAdRegistry removeAllNativeAds];
 }
 
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeModule.mm
@@ -136,8 +136,10 @@ RCT_EXPORT_METHOD(destroy
   for (RNGMANativeAdHolder *adHolder in adHolders) {
     [adHolder dispose];
   }
+  for (NSString *responseId in [_adHolders allKeys]) {
+    [RNGoogleMobileAdsNativeAdRegistry removeNativeAdForResponseId:responseId];
+  }
   [_adHolders removeAllObjects];
-  [RNGoogleMobileAdsNativeAdRegistry removeAllNativeAds];
 }
 
 @end

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsNativeView.mm
@@ -17,7 +17,7 @@
 
 #import "RNGoogleMobileAdsNativeView.h"
 #import "RNGoogleMobileAdsMediaView.h"
-#import "RNGoogleMobileAdsNativeModule.h"
+#import "RNGoogleMobileAdsNativeAdRegistry.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <react/renderer/components/RNGoogleMobileAdsSpec/ComponentDescriptors.h>
@@ -28,10 +28,6 @@
 #import "RCTFabricComponentsPlugins.h"
 #endif
 
-@interface RCTBridge (Private)
-+ (RCTBridge *)currentBridge;
-@end
-
 #ifdef RCT_NEW_ARCH_ENABLED
 using namespace facebook::react;
 
@@ -40,8 +36,9 @@ using namespace facebook::react;
 #endif
 
 @implementation RNGoogleMobileAdsNativeView {
+#ifndef RCT_NEW_ARCH_ENABLED
   __weak RCTBridge *_bridge;
-  __weak RNGoogleMobileAdsNativeModule *_nativeModule;
+#endif
   __weak GADNativeAd *_nativeAd;
   GADNativeAdView *_nativeAdView;
   dispatch_block_t _debouncedReload;
@@ -57,8 +54,6 @@ using namespace facebook::react;
     static const auto defaultProps = std::make_shared<const RNGoogleMobileAdsNativeViewProps>();
     _props = defaultProps;
 
-    _bridge = [RCTBridge currentBridge];
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
     _nativeAdView = [[GADNativeAdView alloc] init];
     self.contentView = _nativeAdView;
   }
@@ -127,7 +122,6 @@ using namespace facebook::react;
 - (instancetype)initWithBridge:(RCTBridge *)bridge {
   if (self = [super init]) {
     _bridge = bridge;
-    _nativeModule = [_bridge moduleForClass:RNGoogleMobileAdsNativeModule.class];
     _nativeAdView = self;
   }
   return self;
@@ -138,8 +132,8 @@ using namespace facebook::react;
 #pragma mark - Common logics
 
 - (void)setResponseId:(NSString *)responseId {
-  _responseId = responseId;
-  _nativeAd = [_nativeModule nativeAdForResponseId:responseId];
+  _responseId = [responseId copy];
+  _nativeAd = [RNGoogleMobileAdsNativeAdRegistry nativeAdForResponseId:responseId];
   [self reloadAd];
 }
 


### PR DESCRIPTION
### Description

Fixes iOS native ad views failing to bind loaded ads in bridgeless / New Architecture mode (Expo SDK 55+, RN 0.85+).

**Problem:** Fabric views initialize when `[RCTBridge currentBridge]` is nil, so they cannot resolve `RNGoogleMobileAdsNativeModule` via the bridge. Without the loaded `GADNativeAd`, media does not render and the CTA is not wired for clicks.

**Solution:** Introduce `RNGoogleMobileAdsNativeAdRegistry` — a process-wide lookup keyed by `responseId`. The native module registers ads on load; native views resolve ads directly from the registry in `setResponseId:` without needing bridge or module access.

This avoids the `sharedInstance` workaround proposed in #845 and #854, which Gemini flagged for:
- **Lazy TurboModule init:** views could capture a nil module at init time
- **Multi-instance apps:** a weak singleton is overwritten by the last module instance

The registry approach resolves ads at use time by `responseId` (which JS already passes after `NativeAd.createForAdRequest()` completes), so neither concern applies.

**Also fixes:** incorrect props type in `RNGoogleMobileAdsMediaView` (`BannerViewProps` → `MediaViewProps`).

**Scope:** iOS only. Android resolves ads via `ReactContext.getNativeModule()` and was not affected by this bridgeless issue in reported cases.

### Related issues

Fixes #858

### Release Summary

iOS native ad views now work correctly in bridgeless (New Architecture) mode.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- [ ] iOS New Architecture: load native ad → media renders → CTA is tappable
- [ ] iOS classic bridge: same flow still works
- [ ] `NativeAd.destroy()` removes ad from registry
- [ ] Module dealloc removes only this instance's ads from registry (multi-instance safe)
