### PR TITLE
fix(android): emit paid event for InterstitialAd (parity with iOS)

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsFullScreenAdModule.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsFullScreenAdModule.kt
@@ -28,6 +28,7 @@ import com.google.android.gms.ads.OnPaidEventListener;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAd
 import com.google.android.gms.ads.appopen.AppOpenAd
+import com.google.android.gms.ads.interstitial.InterstitialAd
 import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
@@ -167,6 +168,7 @@ abstract class ReactNativeGoogleMobileAdsFullScreenAdModule<T>(
 
         when (ad) {
           is AdManagerInterstitialAd -> ad.onPaidEventListener = paidEventListener
+          is InterstitialAd -> ad.onPaidEventListener = paidEventListener
           is AppOpenAd -> ad.onPaidEventListener = paidEventListener
           is RewardedAd -> ad.onPaidEventListener = paidEventListener
           is RewardedInterstitialAd -> ad.onPaidEventListener = paidEventListener


### PR DESCRIPTION
## Summary

On Android, `ReactNativeGoogleMobileAdsFullScreenAdModule` sets `onPaidEventListener` for `AdManagerInterstitialAd`, `AppOpenAd`, `RewardedAd`, and `RewardedInterstitialAd` — but **not** for plain `InterstitialAd`. As a result, `AdEventType.PAID` never fires for standard AdMob interstitials on Android, so impression-level ad revenue (ILRD) cannot be captured on the JS side (e.g. for Singular/AppsFlyer ad-revenue tracking).

iOS already handles this — `RNGoogleMobileAdsFullScreenAd.mm` sets `paidEventHandler` for `GADInterstitialAd`. This brings Android to parity.

## Change

Add `InterstitialAd` to the `when (ad)` block that assigns `onPaidEventListener` (plus the import):

```kotlin
when (ad) {
  is AdManagerInterstitialAd -> ad.onPaidEventListener = paidEventListener
  is InterstitialAd          -> ad.onPaidEventListener = paidEventListener // added
  is AppOpenAd               -> ad.onPaidEventListener = paidEventListener
  is RewardedAd              -> ad.onPaidEventListener = paidEventListener
  is RewardedInterstitialAd  -> ad.onPaidEventListener = paidEventListener
}
```

## Test plan

- Load and show a standard `InterstitialAd` on Android.
- Observe `AdEventType.PAID` now fires with `{ currency, precision, value }`, matching rewarded ads and iOS.

Generated with Claude Code
