### PR TITLE
fix(android): exclude ad views from instance state saving

### DIFF
--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeAdView.kt
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsNativeAdView.kt
@@ -43,6 +43,13 @@ class ReactNativeGoogleMobileAdsNativeAdView(
   private var reloadJob: Job? = null
 
   init {
+    // Exclude the ad view hierarchy from instance state saving/restoring. Mediation
+    // adapters (e.g. Facebook Audience Network) save view state under small view ids
+    // that collide with React Native view tags, causing a crash
+    // ("Wrong state class, expecting View State but received
+    // com.facebook.ads.internal.util.parcelable.WrappedParcelable") when a fragment
+    // (e.g. react-native-screens) restores its view hierarchy state.
+    isSaveFromParentEnabled = false
     nativeAdView.addView(viewGroup)
     addView(nativeAdView)
   }

--- a/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeAdView.java
+++ b/android/src/main/java/io/invertase/googlemobileads/common/ReactNativeAdView.java
@@ -58,6 +58,13 @@ public class ReactNativeAdView extends FrameLayout {
 
   public ReactNativeAdView(final Context context) {
     super(context);
+    // Exclude the ad view hierarchy from instance state saving/restoring. Mediation
+    // adapters (e.g. Facebook Audience Network) save view state under small view ids
+    // that collide with React Native view tags, causing a crash
+    // ("Wrong state class, expecting View State but received
+    // com.facebook.ads.internal.util.parcelable.WrappedParcelable") when a fragment
+    // (e.g. react-native-screens) restores its view hierarchy state.
+    setSaveFromParentEnabled(false);
   }
 
   public void setRequest(AdRequest request) {


### PR DESCRIPTION
### Description

Banner and native ad views can crash on Android when a fragment (for example `react-native-screens`) restores view hierarchy state.

Mediation adapters such as Facebook Audience Network persist view state under small view ids. Those ids collide with React Native view tags, which produces:

```
Wrong state class, expecting View State but received
com.facebook.ads.internal.util.parcelable.WrappedParcelable
```

This disables instance-state save/restore on the ad view wrappers so parent fragments no longer restore adapter-owned state.

### Related issues

None.

### Release Summary

fix(android): exclude ad views from instance state saving to prevent mediation adapter crashes

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Reproduced by navigating away from a screen that shows a GAM banner or native ad mediated by Facebook Audience Network, then returning so `react-native-screens` restores the fragment view state. Without this change the activity crashes; with `setSaveFromParentEnabled(false)` / `isSaveFromParentEnabled = false` the restore succeeds.

:fire:
