### PR TITLE
feat: add neighboringContentUrls request option

### DIFF
--- a/__tests__/requestOptions.test.tsx
+++ b/__tests__/requestOptions.test.tsx
@@ -62,6 +62,54 @@ describe('Admob RequestOptions', () => {
     });
   });
 
+  describe('neighboringContentUrls', () => {
+    it('throws if neighboringContentUrls is not an array', () => {
+      expect(() =>
+        validateAdRequestOptions({
+          // @ts-ignore
+          neighboringContentUrls: 'not-an-array',
+        }),
+      ).toThrow("'options.neighboringContentUrls' expected an array containing string values");
+    });
+
+    it('throws if neighboringContentUrls contains a non-string', () => {
+      expect(() =>
+        validateAdRequestOptions({
+          // @ts-ignore
+          neighboringContentUrls: [123],
+        }),
+      ).toThrow("'options.neighboringContentUrls' expected an array containing string values");
+    });
+
+    it('throws if neighboringContentUrls contains an invalid url', () => {
+      expect(() =>
+        validateAdRequestOptions({
+          neighboringContentUrls: ['not-a-url'],
+        }),
+      ).toThrow("'options.neighboringContentUrls' expected valid HTTP or HTTPS urls.");
+    });
+
+    it('throws if neighboringContentUrls has more than 4 urls', () => {
+      expect(() =>
+        validateAdRequestOptions({
+          neighboringContentUrls: [
+            'https://www.example1.com',
+            'https://www.example2.com',
+            'https://www.example3.com',
+            'https://www.example4.com',
+            'https://www.example5.com',
+          ],
+        }),
+      ).toThrow("'options.neighboringContentUrls' maximum of 4 URLs");
+    });
+
+    it('sets neighboringContentUrls if valid', () => {
+      const urls = ['https://www.example1.com', 'https://www.example2.com'];
+      const result = validateAdRequestOptions({ neighboringContentUrls: urls });
+      expect(result.neighboringContentUrls).toEqual(urls);
+    });
+  });
+
   describe('customTargeting', () => {
     it('throws if customTargeting is not an object', () => {
       expect(() =>

--- a/__tests__/requestOptions.test.tsx
+++ b/__tests__/requestOptions.test.tsx
@@ -103,6 +103,18 @@ describe('Admob RequestOptions', () => {
       ).toThrow("'options.neighboringContentUrls' maximum of 4 URLs");
     });
 
+    it('throws if neighboringContentUrls contains a url that is too long', () => {
+      const longUrl = `https://example.com?${'a'.repeat(512)}`;
+
+      expect(() =>
+        validateAdRequestOptions({
+          neighboringContentUrls: [longUrl],
+        }),
+      ).toThrow(
+        "'options.neighboringContentUrls' maximum length of a content URL is 512 characters.",
+      );
+    });
+
     it('sets neighboringContentUrls if valid', () => {
       const urls = ['https://www.example1.com', 'https://www.example2.com'];
       const result = validateAdRequestOptions({ neighboringContentUrls: urls });

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
@@ -35,7 +35,7 @@ import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import io.invertase.googlemobileads.common.ReactNativeAdView;
 import io.invertase.googlemobileads.common.ReactNativeEventEmitter;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -202,11 +202,11 @@ public class ReactNativeGoogleMobileAdsCommon {
     if (adRequestOptions.hasKey("neighboringContentUrls")) {
       ReadableArray neighboringContentUrls =
           Objects.requireNonNull(adRequestOptions.getArray("neighboringContentUrls"));
-      HashSet<String> urlSet = new HashSet<>();
+      List<String> urls = new ArrayList<>();
       for (int i = 0; i < neighboringContentUrls.size(); i++) {
-        urlSet.add(neighboringContentUrls.getString(i));
+        urls.add(neighboringContentUrls.getString(i));
       }
-      builder.setNeighboringContentUrls(urlSet);
+      builder.setNeighboringContentUrls(urls);
     }
 
     if (adRequestOptions.hasKey("requestAgent")) {

--- a/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
+++ b/android/src/main/java/io/invertase/googlemobileads/ReactNativeGoogleMobileAdsCommon.java
@@ -35,6 +35,7 @@ import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import io.invertase.googlemobileads.common.ReactNativeAdView;
 import io.invertase.googlemobileads.common.ReactNativeEventEmitter;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -196,6 +197,16 @@ public class ReactNativeGoogleMobileAdsCommon {
 
     if (adRequestOptions.hasKey("contentUrl")) {
       builder.setContentUrl(Objects.requireNonNull(adRequestOptions.getString("contentUrl")));
+    }
+
+    if (adRequestOptions.hasKey("neighboringContentUrls")) {
+      ReadableArray neighboringContentUrls =
+          Objects.requireNonNull(adRequestOptions.getArray("neighboringContentUrls"));
+      HashSet<String> urlSet = new HashSet<>();
+      for (int i = 0; i < neighboringContentUrls.size(); i++) {
+        urlSet.add(neighboringContentUrls.getString(i));
+      }
+      builder.setNeighboringContentUrls(urlSet);
     }
 
     if (adRequestOptions.hasKey("requestAgent")) {

--- a/docs/displaying-ads-hook.mdx
+++ b/docs/displaying-ads-hook.mdx
@@ -26,7 +26,7 @@ If `adUnitid` is set or changed, new ad instance will be created and previous ad
 If `adUnitid` is set to `null`, no ad instance will be created and previous ad instance will be destroyed if exists.
 </Info>
 
-The second argument is an additional optional request options object to be sent whilst loading an advert, such as keywords & location.
+The second argument is an additional optional request options object to be sent whilst loading an advert, such as keywords, location, and [content URLs](/displaying-ads#content-url-targeting-brand-safety).
 Setting additional request options helps AdMob choose better tailored ads from the network.
 View the [`RequestOptions`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/RequestOptions.ts) source code to see the full range of options available.
 

--- a/docs/displaying-ads.mdx
+++ b/docs/displaying-ads.mdx
@@ -79,9 +79,32 @@ const interstitial = InterstitialAd.createForAdRequest(adUnitId, {
 });
 ```
 
-The second argument is additional optional request options object to be sent whilst loading an advert, such as keywords & location.
+The second argument is additional optional request options object to be sent whilst loading an advert, such as keywords, location, and content URLs.
 Setting additional request options helps AdMob choose better tailored ads from the network.
 View the [`RequestOptions`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/RequestOptions.ts) source code to see the full range of options available.
+
+### Content URL targeting (brand safety)
+
+When an ad sits next to web-like content (for example an article in a feed), you can pass the page URL and nearby URLs so Google can apply a more appropriate content rating.
+
+- `contentUrl`: the URL of the content currently being displayed (max 512 characters, HTTP or HTTPS).
+- `neighboringContentUrls`: up to 4 nearby content URLs (each max 512 characters, HTTP or HTTPS).
+
+These options apply to any ad loaded with `RequestOptions` (`createForAdRequest`, banner `requestOptions`, [hooks](/displaying-ads-hook), [native ads](/native-ads)).
+
+```js
+import { InterstitialAd, TestIds } from 'react-native-google-mobile-ads';
+
+const interstitial = InterstitialAd.createForAdRequest(TestIds.INTERSTITIAL, {
+  contentUrl: 'https://www.example.com/article-a',
+  neighboringContentUrls: [
+    'https://www.example.com/article-b',
+    'https://www.example.com/article-c',
+  ],
+});
+```
+
+See Google's [brand safety targeting](https://developers.google.com/ad-manager/mobile-ads-sdk/android/targeting#content_url) docs for platform details.
 
 The call to `createForAdRequest` returns an instance of the [`InterstitialAd`](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/ads/InterstitialAd.ts) class,
 which provides a number of utilities for loading and displaying interstitials.
@@ -423,7 +446,7 @@ import { BannerAd, BannerAdSize, TestIds, useForeground } from 'react-native-goo
 const adUnitId = __DEV__ ? TestIds.ADAPTIVE_BANNER : 'ca-app-pub-xxxxxxxxxxxxx/yyyyyyyyyyyyyy';
 
 function App() {
-  const bannerRef = useRef<BannerAd>(null);
+  const bannerRef = useRef < BannerAd > null;
 
   // (iOS) WKWebView can terminate if app is in a "suspended state", resulting in an empty banner when app returns to foreground.
   // Therefore it's advised to "manually" request a new ad when the app is foregrounded (https://groups.google.com/g/google-admob-ads-sdk/c/rwBpqOUr8m8).
@@ -432,7 +455,11 @@ function App() {
   });
 
   return (
-    <BannerAd ref={bannerRef} unitId={adUnitId} size={BannerAdSize.LARGE_ANCHORED_ADAPTIVE_BANNER} />
+    <BannerAd
+      ref={bannerRef}
+      unitId={adUnitId}
+      size={BannerAdSize.LARGE_ANCHORED_ADAPTIVE_BANNER}
+    />
   );
 }
 ```

--- a/docs/native-ads.mdx
+++ b/docs/native-ads.mdx
@@ -88,7 +88,7 @@ NativeAd.createForAdRequest(TestIds.NATIVE, {
 ```
 
 #### Other Ad Request Options
-You can specify other request options to be sent while loading an advert, such as keywords and location.
+You can specify other request options to be sent while loading an advert, such as keywords, location, and [content URLs](/displaying-ads#content-url-targeting-brand-safety).
 Setting additional request options helps AdMob choose better tailored ads from the network.
 View the [RequestOptions](https://github.com/invertase/react-native-google-mobile-ads/blob/main/src/types/RequestOptions.ts) source code to see the full range of options available.
 

--- a/e2e/requestOptions.e2e.js
+++ b/e2e/requestOptions.e2e.js
@@ -44,6 +44,7 @@ describe('googleAds requestOptions', function () {
       keywords: undefined,
       testDevices: undefined,
       contentUrl: undefined,
+      neighboringContentUrls: undefined,
       location: undefined,
       locationAccuracy: undefined,
       requestAgent: undefined,
@@ -55,6 +56,7 @@ describe('googleAds requestOptions', function () {
     v.keywords.should.eql(undefined);
     v.testDevices.should.eql(undefined);
     v.contentUrl.should.eql(undefined);
+    v.neighboringContentUrls.should.eql(undefined);
     v.location.should.eql(undefined);
     v.locationAccuracy.should.eql(undefined);
     v.requestAgent.should.eql(undefined);
@@ -261,6 +263,96 @@ describe('googleAds requestOptions', function () {
       });
 
       v.contentUrl.should.be.eql('http://invertase.io/privacy-policy');
+    });
+  });
+
+  describe('neighboringContentUrls', function () {
+    it('throws if neighboringContentUrls is not an array', function () {
+      try {
+        validator({
+          neighboringContentUrls: 'not-an-array',
+        });
+        return Promise.reject(new Error('Did not throw Error.'));
+      } catch (e) {
+        e.message.should.containEql(
+          "'options.neighboringContentUrls' expected an array containing string values",
+        );
+        return Promise.resolve();
+      }
+    });
+
+    it('throws if neighboringContentUrls contains a non-string', function () {
+      try {
+        validator({
+          neighboringContentUrls: [123],
+        });
+        return Promise.reject(new Error('Did not throw Error.'));
+      } catch (e) {
+        e.message.should.containEql(
+          "'options.neighboringContentUrls' expected an array containing string values",
+        );
+        return Promise.resolve();
+      }
+    });
+
+    it('throws if neighboringContentUrls contains an invalid url', function () {
+      try {
+        validator({
+          neighboringContentUrls: ['www.invertase.io'],
+        });
+        return Promise.reject(new Error('Did not throw Error.'));
+      } catch (e) {
+        e.message.should.containEql(
+          "'options.neighboringContentUrls' expected valid HTTP or HTTPS urls.",
+        );
+        return Promise.resolve();
+      }
+    });
+
+    it('throws if neighboringContentUrls contains a url that is too long', function () {
+      let str = '';
+      for (let i = 0; i < 530; i++) {
+        str += i.toString();
+      }
+
+      try {
+        validator({
+          neighboringContentUrls: [`https://invertase.io?${str}`],
+        });
+        return Promise.reject(new Error('Did not throw Error.'));
+      } catch (e) {
+        e.message.should.containEql(
+          "'options.neighboringContentUrls' maximum length of a content URL is 512 characters",
+        );
+        return Promise.resolve();
+      }
+    });
+
+    it('throws if neighboringContentUrls has more than 4 urls', function () {
+      try {
+        validator({
+          neighboringContentUrls: [
+            'https://www.example1.com',
+            'https://www.example2.com',
+            'https://www.example3.com',
+            'https://www.example4.com',
+            'https://www.example5.com',
+          ],
+        });
+        return Promise.reject(new Error('Did not throw Error.'));
+      } catch (e) {
+        e.message.should.containEql("'options.neighboringContentUrls' maximum of 4 URLs");
+        return Promise.resolve();
+      }
+    });
+
+    it('accepts neighboringContentUrls', function () {
+      const urls = ['http://invertase.io/article-a', 'https://invertase.io/article-b'];
+      const v = validator({
+        neighboringContentUrls: urls,
+      });
+
+      v.neighboringContentUrls.should.be.eql(urls);
     });
   });
 

--- a/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.mm
+++ b/ios/RNGoogleMobileAds/RNGoogleMobileAdsCommon.mm
@@ -84,6 +84,10 @@ NSString *const GOOGLE_MOBILE_ADS_EVENT_REWARDED_EARNED_REWARD = @"rewarded_earn
     request.contentURL = adRequestOptions[@"contentUrl"];
   }
 
+  if (adRequestOptions[@"neighboringContentUrls"]) {
+    request.neighboringContentURLStrings = adRequestOptions[@"neighboringContentUrls"];
+  }
+
   if (adRequestOptions[@"requestAgent"]) {
     request.requestAgent = adRequestOptions[@"requestAgent"];
   }

--- a/src/types/RequestOptions.ts
+++ b/src/types/RequestOptions.ts
@@ -65,9 +65,24 @@ export interface RequestOptions {
   keywords?: string[];
 
   /**
-   * Sets a content URL for targeting purposes.
+   * URL of the content currently being displayed. Used for brand safety so
+   * displayed ads can have a content rating more appropriate to that page.
    *
-   * Max length of 512.
+   * HTTP or HTTPS only. Max length of 512.
+   *
+   * Pair with {@link RequestOptions.neighboringContentUrls} when the ad sits
+   * next to other web content (for example articles in a feed).
+   *
+   * #### Example
+   *
+   * ```js
+   * await Interstitial.createForAdRequest('ca-app-pub-3940256099942544/1033173712', {
+   *   contentUrl: 'https://www.example.com/article-a',
+   * });
+   * ```
+   *
+   * @see https://developers.google.com/ad-manager/mobile-ads-sdk/android/targeting#content_url
+   * @see https://developers.google.com/ad-manager/mobile-ads-sdk/ios/targeting#content_url
    */
   contentUrl?: string;
 
@@ -75,19 +90,23 @@ export interface RequestOptions {
    * URLs representing web content near an ad. Used for brand safety so displayed
    * ads can have a content rating more appropriate to neighboring content.
    *
-   * Maximum of 4 URLs. Each URL max length of 512.
+   * HTTP or HTTPS only. Maximum of 4 URLs. Each URL max length of 512.
+   *
+   * Pair with {@link RequestOptions.contentUrl} for the page currently on screen.
    *
    * #### Example
    *
    * ```js
    * await Interstitial.createForAdRequest('ca-app-pub-3940256099942544/1033173712', {
+   *   contentUrl: 'https://www.example.com/article-a',
    *   neighboringContentUrls: [
-   *     'https://www.example1.com',
-   *     'https://www.example2.com',
+   *     'https://www.example.com/article-b',
+   *     'https://www.example.com/article-c',
    *   ],
    * });
    * ```
    *
+   * @see https://developers.google.com/ad-manager/mobile-ads-sdk/android/targeting#content_url
    * @see https://developers.google.com/ad-manager/mobile-ads-sdk/ios/targeting#brand_safety_beta
    */
   neighboringContentUrls?: string[];

--- a/src/types/RequestOptions.ts
+++ b/src/types/RequestOptions.ts
@@ -72,6 +72,27 @@ export interface RequestOptions {
   contentUrl?: string;
 
   /**
+   * URLs representing web content near an ad. Used for brand safety so displayed
+   * ads can have a content rating more appropriate to neighboring content.
+   *
+   * Maximum of 4 URLs. Each URL max length of 512.
+   *
+   * #### Example
+   *
+   * ```js
+   * await Interstitial.createForAdRequest('ca-app-pub-3940256099942544/1033173712', {
+   *   neighboringContentUrls: [
+   *     'https://www.example1.com',
+   *     'https://www.example2.com',
+   *   ],
+   * });
+   * ```
+   *
+   * @see https://developers.google.com/ad-manager/mobile-ads-sdk/ios/targeting#brand_safety_beta
+   */
+  neighboringContentUrls?: string[];
+
+  /**
    * key-value pairs used for custom targeting
    *
    * Takes an object of keys with values of string, number, or arrays of strings/numbers.

--- a/src/validateAdRequestOptions.ts
+++ b/src/validateAdRequestOptions.ts
@@ -94,6 +94,40 @@ export function validateAdRequestOptions(options?: RequestOptions) {
     out.contentUrl = options.contentUrl;
   }
 
+  if (options.neighboringContentUrls) {
+    if (!isArray(options.neighboringContentUrls)) {
+      throw new Error(
+        "'options.neighboringContentUrls' expected an array containing string values",
+      );
+    }
+
+    if (options.neighboringContentUrls.length > 4) {
+      throw new Error("'options.neighboringContentUrls' maximum of 4 URLs");
+    }
+
+    for (let i = 0; i < options.neighboringContentUrls.length; i++) {
+      const url = options.neighboringContentUrls[i];
+
+      if (!isString(url)) {
+        throw new Error(
+          "'options.neighboringContentUrls' expected an array containing string values",
+        );
+      }
+
+      if (!isValidUrl(url)) {
+        throw new Error("'options.neighboringContentUrls' expected valid HTTP or HTTPS urls.");
+      }
+
+      if (url.length > 512) {
+        throw new Error(
+          "'options.neighboringContentUrls' maximum length of a content URL is 512 characters.",
+        );
+      }
+    }
+
+    out.neighboringContentUrls = options.neighboringContentUrls;
+  }
+
   if (options.requestAgent) {
     if (!isString(options.requestAgent)) {
       throw new Error("'options.requestAgent' expected a string value");


### PR DESCRIPTION
### Description

Google Mobile Ads supports neighboring content URLs for brand safety on both platforms (`GADRequest.neighboringContentURLStrings` on iOS, `AdRequest.Builder.setNeighboringContentUrls` on Android). This library already exposes `contentUrl`, but not the neighboring URLs used when an ad sits next to other web content (for example articles in a feed).

This adds `neighboringContentUrls` to `RequestOptions`:

```js
await Interstitial.createForAdRequest(adUnitId, {
  contentUrl: 'https://www.example.com/article-a',
  neighboringContentUrls: [
    'https://www.example.com/article-b',
    'https://www.example.com/article-c',
  ],
});
```

Validation matches `contentUrl`: HTTP(S) only, max 512 characters per URL, and a maximum of 4 URLs as documented by Google.

### Related issues

None.

### Release Summary

feat: add neighboringContentUrls request option for brand-safety targeting

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [x] `jest` tests added or updated in `__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Jest coverage in `__tests__/requestOptions.test.tsx` for type, URL, length, and max-count validation.
- Native mapping verified against GMA iOS 13.5 (`neighboringContentURLStrings`) and Android `setNeighboringContentUrls`.

:fire:
