### PR TITLE
fix(native-ad): correct paid event payload key to `currency` (#877)

### DIFF
--- a/src/specs/modules/NativeGoogleMobileAdsNativeModule.ts
+++ b/src/specs/modules/NativeGoogleMobileAdsNativeModule.ts
@@ -58,7 +58,7 @@ export type NativeAdEventPayload = {
 export type NativeAdPaidEventPayload = {
   value: number;
   precision: number;
-  currencyCode: string;
+  currency: string;
 };
 
 export interface Spec extends TurboModule {


### PR DESCRIPTION
## What

Fixes #877.

The `NativeAd` PAID event payload type declares `currencyCode`:

```ts
export type NativeAdPaidEventPayload = {
  value: number;
  precision: number;
  currencyCode: string;
};
```

but every native emitter sends the JavaScript key `currency`, not `currencyCode`. For example, on Android:

```kotlin
// android/.../ReactNativeGoogleMobileAdsNativeModule.kt
revenueData.putString("currency", adValue.currencyCode)
```

and the same on iOS (`RNGoogleMobileAdsNativeModule.mm`: `@"currency" : adValue.currencyCode`). So `payload.currencyCode` type-checks but is `undefined` at runtime — the value is on `payload.currency`.

This is the NativeAd counterpart of the same key: the shared `PaidEvent` type (`src/types/PaidEventListener.ts`) and the banner/full-screen `BaseAd` payload already use `currency`; only this TurboModule spec type was out of sync.

## Fix

Rename the field to `currency` so the type matches the bridge and the rest of the codebase:

```diff
 export type NativeAdPaidEventPayload = {
   value: number;
   precision: number;
-  currencyCode: string;
+  currency: string;
 };
```

## Verification

- `yarn tsc:compile` — clean.
- `yarn tests:jest` — all suites pass (no test read `currencyCode`; the only other `currencyCode` references in the tree are the native Google SDK's own field, which is unrelated).
- `eslint` on the changed file — clean.

## Note

This corrects the type to reflect the actual runtime payload. Any code currently reading `payload.currencyCode` was already receiving `undefined`; it should read `payload.currency` (which now type-checks).
