### PR TITLE
fix(native-ad): align paid event currency payload type

### DIFF
--- a/__tests__/nativeAd.test.ts
+++ b/__tests__/nativeAd.test.ts
@@ -1,0 +1,50 @@
+import { NativeAd, NativeAdEventType } from '../src';
+import NativeGoogleMobileAdsNativeModule from '../src/specs/modules/NativeGoogleMobileAdsNativeModule';
+
+const nativeAdProps = {
+  responseId: 'native-ad-response-id',
+  advertiser: null,
+  body: 'Body',
+  callToAction: 'Install',
+  headline: 'Headline',
+  price: null,
+  store: null,
+  starRating: null,
+  icon: null,
+  images: null,
+  mediaContent: null,
+  extras: null,
+};
+
+describe('NativeAd', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards the paid event currency payload', async () => {
+    const nativeModule = NativeGoogleMobileAdsNativeModule as unknown as {
+      load: jest.Mock;
+      onAdEvent: jest.Mock;
+    };
+    nativeModule.load.mockResolvedValue(nativeAdProps);
+
+    const nativeAd = await NativeAd.createForAdRequest('native-ad-unit-id');
+    const listener = jest.fn();
+    nativeAd.addAdEventListener(NativeAdEventType.PAID, listener);
+
+    const nativeEventListener = nativeModule.onAdEvent.mock.calls[0][0];
+    nativeEventListener({
+      responseId: nativeAdProps.responseId,
+      type: NativeAdEventType.PAID,
+      value: 1.5,
+      precision: 3,
+      currency: 'USD',
+    });
+
+    expect(listener).toHaveBeenCalledWith({
+      value: 1.5,
+      precision: 3,
+      currency: 'USD',
+    });
+  });
+});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -23,6 +23,14 @@ jest.doMock('react-native', () => {
       TurboModuleRegistry: {
         ...ReactNative.TurboModuleRegistry,
         getEnforcing: moduleName => {
+          if (moduleName === 'RNGoogleMobileAdsNativeModule') {
+            return {
+              load: jest.fn(),
+              destroy: jest.fn(),
+              onAdEvent: jest.fn(),
+            };
+          }
+
           if (moduleName === 'RNGoogleMobileAdsInterstitialModule') {
             return {
               interstitialLoad: jest.fn(),

--- a/src/specs/modules/NativeGoogleMobileAdsNativeModule.ts
+++ b/src/specs/modules/NativeGoogleMobileAdsNativeModule.ts
@@ -58,7 +58,7 @@ export type NativeAdEventPayload = {
 export type NativeAdPaidEventPayload = {
   value: number;
   precision: number;
-  currencyCode: string;
+  currency: string;
 };
 
 export interface Spec extends TurboModule {

--- a/type-test.ts
+++ b/type-test.ts
@@ -27,6 +27,8 @@ import mobileAds, {
   useRewardedAd,
   useRewardedInterstitialAd,
   useForeground,
+  NativeAd,
+  NativeAdEventType,
 } from './src';
 
 // static exports
@@ -287,3 +289,15 @@ console.log(useRewardedInterstitialAd);
 
 // useForeground
 console.log(useForeground);
+
+// NativeAd
+async function testNativeAdPaidEvent() {
+  const nativeAd = await NativeAd.createForAdRequest('foo');
+  nativeAd.addAdEventListener(NativeAdEventType.PAID, event => {
+    console.log(event.currency);
+    console.log(event.precision);
+    console.log(event.value);
+  });
+}
+
+testNativeAdPaidEvent();


### PR DESCRIPTION
### Description

NativeAd.addAdEventListener(NativeAdEventType.PAID, ...) exposes a payload type
with currencyCode, but both native implementations emit the JavaScript payload
key as currency.

TypeScript accepts payload.currencyCode, but that property is undefined at
runtime. The actual value is available at payload.currency.


### Related issues

Fixes #877

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
