### PR TITLE
fix: declare react and react-native peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,9 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "expo": ">=47.0.0"
+    "expo": ">=47.0.0",
+    "react": "*",
+    "react-native": "*"
   },
   "peerDependenciesMeta": {
     "expo": {


### PR DESCRIPTION
### Description

`react-native-google-mobile-ads` requires `react` and `react-native` at runtime but declares neither as a peer dependency — its only peer is an optional `expo`:

```json
"peerDependencies": { "expo": ">=47.0.0" }
```

Package managers with isolated/strict layouts (pnpm's `node-linker=isolated`) key module linking off declared peers. With no `react` peer, pnpm creates no `react` sibling link in the library's virtual-store instance, so its `require('react')` falls through to pnpm's hidden fallback (`node_modules/.pnpm/node_modules/react`) — which resolves to *whichever* React pnpm hoisted there. In a monorepo containing more than one React (e.g. an RN app plus a Next.js web app), that can be a different copy than the app's, and the first rendered `NativeAdView` crashes with:

```
Invalid hook call ... You might have more than one copy of React
Render Error: Cannot read property 'useRef' of null   (NativeAdView.tsx:29)
```

Full evidence (virtual-store listings, `readlink` of the fallback, comparison with a correctly-declaring native module) is in #876.

This PR declares the peers the library actually requires, matching the declaration [react-native-firebase uses](https://github.com/invertase/react-native-firebase/blob/main/packages/app/package.json):

```json
"peerDependencies": {
  "expo": ">=47.0.0",
  "react": "*",
  "react-native": "*"
}
```

Blast radius: every consumer of this library necessarily has both packages installed, and `*` cannot introduce a version conflict — the change only informs resolvers/linkers that the dependency exists. npm/yarn behavior is unchanged; pnpm isolated installs get a correct sibling link instead of the hidden fallback.

### Related issues

Fixes #876

### Release Summary

Declare `react` and `react-native` as peer dependencies so strict/isolated package managers (pnpm) link the app's React copy instead of falling back to an arbitrary hoisted one (fixes "Invalid hook call" / duplicate React in monorepos).

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-mobile-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

(Manifest-only change — no code paths touched, so no tests or type updates apply.)

### Test Plan

Verified in the pnpm workspace where the bug reproduces (details in #876): with the peer declared, the library's virtual-store instance gains `react`/`react-native` sibling links pointing at the app's copies, matching every other RN native module in the app; the duplicate-React crash on ad fill no longer reproduces without the Metro `resolveRequest` workaround.

---

Think `react-native-google-mobile-ads` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter

🔥
